### PR TITLE
Added ZenEngine related API implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@gorules/zen-engine": "^0.23.0",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/mongoose": "^10.0.5",
         "@nestjs/platform-express": "^10.3.7",
         "axios": "^1.6.8",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "mongoose": "^8.3.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
@@ -1016,6 +1019,96 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine/-/zen-engine-0.23.0.tgz",
+      "integrity": "sha512-MZruauQe8l1B2onB1b1V4/kZh7WSZclQUVQVIAJvRhx8doni6EQNpBzYmZ+AItAVmoDjUazjCyVC8yLL+xVpkg==",
+      "engines": {
+        "node": ">= 14"
+      },
+      "optionalDependencies": {
+        "@gorules/zen-engine-darwin-arm64": "0.23.0",
+        "@gorules/zen-engine-darwin-x64": "0.23.0",
+        "@gorules/zen-engine-linux-arm64-gnu": "0.23.0",
+        "@gorules/zen-engine-linux-x64-gnu": "0.23.0",
+        "@gorules/zen-engine-win32-x64-msvc": "0.23.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine-darwin-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-darwin-arm64/-/zen-engine-darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-sVYoUh9Rk+sv/AcuXk4GSmGKTyx1v+FKYPe9qS4fU/yeAhey3fp9uU05hGjIK0ntA+HmJKeFjvXZyvTLyAETKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-darwin-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-darwin-x64/-/zen-engine-darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-G8SBsa6XPJ4fijHzkpYOT2MRGqzt8vRCat+aEvtynrHYHNjzQXmhEkkcvfX/UHl3TIAZvknYbuEZzCnXcLi+uQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-arm64-gnu": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-arm64-gnu/-/zen-engine-linux-arm64-gnu-0.23.0.tgz",
+      "integrity": "sha512-fuKub3xmJr1y28736az488mZaV1mEvhtZPYzsad3jLEqy8OkiUN3lcN2fxQN2Hjo2/aFL4go3SIZ1uBdrzu5Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-x64-gnu": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-x64-gnu/-/zen-engine-linux-x64-gnu-0.23.0.tgz",
+      "integrity": "sha512-mhWqJ0+k+V5ih2xrompAWQD+H+cOUAPSCxB1QPJho5uipEN6GSQJKlgBIP9Ip3TnrW2Qbxn0ORUaO2L6igg1yw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-win32-x64-msvc": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-win32-x64-msvc/-/zen-engine-win32-x64-msvc-0.23.0.tgz",
+      "integrity": "sha512-KD+qJka+7VCSROIZ8PfnU13fTH5+iuFU9FZJaqBzkyMCAfIXwRUvzDDcI0KYtrLsl2Eqc8wvFQCznflhbxlR6w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2340,6 +2433,11 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.10.tgz",
+      "integrity": "sha512-e2PNXoXLr6Z+dbfx5zSh9TRlXJrELycxiaXznp4S5+D2M3b9bqJEitNHA5923jhnB2zzFiZHa2f0SI1HoIahpg=="
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -3429,6 +3527,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6281,6 +6394,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.2.tgz",
+      "integrity": "sha512-V9mGLlaXN1WETzqQvSu6qf6XVAr3nFuJvWsHcuzCCCo6xUKawwSxOPTpan5CGOSKTn5w/bQuCZcLPJkyysgC3w=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8780,6 +8898,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,15 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@gorules/zen-engine": "^0.23.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/mongoose": "^10.0.5",
     "@nestjs/platform-express": "^10.3.7",
     "axios": "^1.6.8",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "mongoose": "^8.3.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"

--- a/src/api/decisions/decisions.controller.ts
+++ b/src/api/decisions/decisions.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Post, Param, Body, HttpException, HttpStatus } from '@nestjs/common';
+import { DecisionsService } from './decisions.service';
+import { EvaluateDecisionDto, EvaluateDecisionWithContentDto } from './dto/evaluate-decision.dto';
+
+@Controller('api/decisions')
+export class DecisionsController {
+  constructor(private readonly decisionsService: DecisionsService) {}
+
+  @Post('/evaluate')
+  async evaluateDecisionByContent(@Body() { content, context, trace }: EvaluateDecisionWithContentDto) {
+    try {
+      return await this.decisionsService.runDecision(content, context, { trace });
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Post('/evaluate/:ruleFileName')
+  async evaluateDecisionByFile(
+    @Param('ruleFileName') ruleFileName: string,
+    @Body() { context, trace }: EvaluateDecisionDto,
+  ) {
+    try {
+      return await this.decisionsService.runDecisionByFile(ruleFileName, context, { trace });
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DecisionsService } from './decisions.service';
+import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
+import { readFile } from 'fs/promises';
+
+jest.mock('fs/promises');
+
+describe('DecisionsService', () => {
+  let service: DecisionsService;
+  let mockEngine: Partial<ZenEngine>;
+  let mockDecision: Partial<ZenDecision>;
+
+  beforeEach(async () => {
+    mockDecision = {
+      evaluate: jest.fn(),
+    };
+    mockEngine = {
+      createDecision: jest.fn().mockReturnValue(mockDecision),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DecisionsService, { provide: ZenEngine, useValue: mockEngine }],
+    }).compile();
+
+    service = module.get<DecisionsService>(DecisionsService);
+    service.engine = mockEngine as ZenEngine;
+  });
+
+  describe('runDecision', () => {
+    it('should run a decision', async () => {
+      const content = {};
+      const context = {};
+      const options: ZenEvaluateOptions = { trace: false };
+      await service.runDecision(content, context, options);
+      expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
+      expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
+    });
+
+    it('should throw an error if the decision fails', async () => {
+      const content = {};
+      const context = {};
+      const options: ZenEvaluateOptions = { trace: false };
+      (mockDecision.evaluate as jest.Mock).mockRejectedValue(new Error('Error'));
+      await expect(service.runDecision(content, context, options)).rejects.toThrow('Failed to run decision: Error');
+    });
+  });
+
+  describe('runDecisionByFile', () => {
+    it('should read a file and run a decision', async () => {
+      const ruleFileName = 'rule';
+      const context = {};
+      const options: ZenEvaluateOptions = { trace: false };
+      const content = JSON.stringify({ rule: 'rule' });
+      (readFile as jest.Mock).mockResolvedValue(content);
+      await service.runDecisionByFile(ruleFileName, context, options);
+      expect(readFile).toHaveBeenCalledWith(`src/rules/${ruleFileName}`);
+      expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
+      expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
+    });
+
+    it('should throw an error if reading the file fails', async () => {
+      const ruleFileName = 'rule';
+      const context = {};
+      const options: ZenEvaluateOptions = { trace: false };
+      (readFile as jest.Mock).mockRejectedValue(new Error('Error'));
+      await expect(service.runDecisionByFile(ruleFileName, context, options)).rejects.toThrow(
+        'Failed to run decision: Error',
+      );
+    });
+  });
+});

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -1,0 +1,32 @@
+import { readFile } from 'fs/promises';
+import { Injectable } from '@nestjs/common';
+import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
+
+const RULES_DIRECTORY = 'src/rules';
+
+@Injectable()
+export class DecisionsService {
+  engine: ZenEngine;
+
+  constructor() {
+    this.engine = new ZenEngine();
+  }
+
+  async runDecision(content: object, context: object, options: ZenEvaluateOptions) {
+    try {
+      const decision = this.engine.createDecision(content);
+      return await decision.evaluate(context, options);
+    } catch (error) {
+      throw new Error(`Failed to run decision: ${error.message}`);
+    }
+  }
+
+  async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions) {
+    try {
+      const content = await readFile(`${RULES_DIRECTORY}/${ruleFileName}`);
+      return this.runDecision(content, context, options);
+    } catch (error) {
+      throw new Error(`Failed to run decision: ${error.message}`);
+    }
+  }
+}

--- a/src/api/decisions/decsions.controller.spec.ts
+++ b/src/api/decisions/decsions.controller.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException } from '@nestjs/common';
+import { DecisionsController } from './decisions.controller';
+import { DecisionsService } from './decisions.service';
+import { EvaluateDecisionDto, EvaluateDecisionWithContentDto } from './dto/evaluate-decision.dto';
+
+describe('DecisionsController', () => {
+  let controller: DecisionsController;
+  let service: DecisionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DecisionsController],
+      providers: [
+        {
+          provide: DecisionsService,
+          useValue: {
+            runDecision: jest.fn(),
+            runDecisionByFile: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DecisionsController>(DecisionsController);
+    service = module.get<DecisionsService>(DecisionsService);
+  });
+
+  it('should call runDecision with correct parameters', async () => {
+    const dto: EvaluateDecisionWithContentDto = {
+      content: { value: 'content' },
+      context: { value: 'context' },
+      trace: false,
+    };
+    await controller.evaluateDecisionByContent(dto);
+    expect(service.runDecision).toHaveBeenCalledWith(dto.content, dto.context, { trace: dto.trace });
+  });
+
+  it('should throw an error when runDecision fails', async () => {
+    const dto: EvaluateDecisionWithContentDto = {
+      content: { value: 'content' },
+      context: { value: 'context' },
+      trace: false,
+    };
+    (service.runDecision as jest.Mock).mockRejectedValue(new Error('Error'));
+    await expect(controller.evaluateDecisionByContent(dto)).rejects.toThrow(HttpException);
+  });
+
+  it('should call runDecisionByFile with correct parameters', async () => {
+    const dto: EvaluateDecisionDto = { context: { value: 'context' }, trace: false };
+    const ruleFileName = 'rule';
+    await controller.evaluateDecisionByFile(ruleFileName, dto);
+    expect(service.runDecisionByFile).toHaveBeenCalledWith(ruleFileName, dto.context, { trace: dto.trace });
+  });
+
+  it('should throw an error when runDecisionByFile fails', async () => {
+    const dto: EvaluateDecisionDto = { context: { value: 'context' }, trace: false };
+    const ruleFileName = 'rule';
+    (service.runDecisionByFile as jest.Mock).mockRejectedValue(new Error('Error'));
+    await expect(controller.evaluateDecisionByFile(ruleFileName, dto)).rejects.toThrow(HttpException);
+  });
+});

--- a/src/api/decisions/dto/evaluate-decision.dto.ts
+++ b/src/api/decisions/dto/evaluate-decision.dto.ts
@@ -1,0 +1,14 @@
+import { IsBoolean, IsObject } from 'class-validator';
+
+export class EvaluateDecisionDto {
+  @IsObject()
+  context: object;
+
+  @IsBoolean()
+  trace: boolean;
+}
+
+export class EvaluateDecisionWithContentDto extends EvaluateDecisionDto {
+  @IsObject()
+  content: object;
+}

--- a/src/api/documents/documents.controller.spec.ts
+++ b/src/api/documents/documents.controller.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DocumentsController } from './documents.controller';
+import { DocumentsService } from './documents.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+
+describe('DocumentsController', () => {
+  let documentsController: DocumentsController;
+  let documentsService: DocumentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DocumentsController],
+      providers: [
+        {
+          provide: DocumentsService,
+          useValue: {
+            getFileContent: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    documentsController = module.get<DocumentsController>(DocumentsController);
+    documentsService = module.get<DocumentsService>(DocumentsService);
+  });
+
+  it('should return file content', async () => {
+    const ruleFileName = 'test.json';
+    const mockFileContent = Buffer.from(JSON.stringify({ key: 'value' }));
+    const res = {
+      setHeader: jest.fn(),
+      send: jest.fn(),
+    } as unknown as Response;
+
+    jest.spyOn(documentsService, 'getFileContent').mockResolvedValueOnce(mockFileContent);
+
+    await documentsController.getRuleFile(ruleFileName, res);
+    expect(res.send).toHaveBeenCalledWith(mockFileContent);
+  });
+
+  it('should throw an error when file not found', async () => {
+    const ruleFileName = 'test.json';
+    const mockError = new Error('File not found');
+    const res = {
+      setHeader: jest.fn(),
+      send: jest.fn(),
+    } as unknown as Response;
+
+    jest.spyOn(documentsService, 'getFileContent').mockRejectedValueOnce(mockError);
+
+    await expect(documentsController.getRuleFile(ruleFileName, res)).rejects.toThrow(
+      new HttpException(mockError.message, HttpStatus.INTERNAL_SERVER_ERROR),
+    );
+  });
+});

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, Res, HttpException, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import { DocumentsService } from './documents.service';
+
+@Controller('api/documents')
+export class DocumentsController {
+  constructor(private readonly documentsService: DocumentsService) {}
+
+  @Get('/:ruleFileName')
+  async getRuleFile(@Param('ruleFileName') ruleFileName: string, @Res() res: Response) {
+    const filePath = `src/rules/${ruleFileName}`;
+    const fileContent = await this.documentsService.getFileContent(filePath);
+
+    try {
+      res.setHeader('Content-Type', 'application/json');
+      res.setHeader('Content-Disposition', `attachment; filename=${ruleFileName}`);
+      res.send(fileContent);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/api/documents/documents.service.spec.ts
+++ b/src/api/documents/documents.service.spec.ts
@@ -1,0 +1,44 @@
+import { DocumentsService } from './documents.service'; // Adjust the path as needed
+import { HttpException, HttpStatus } from '@nestjs/common';
+import * as fs from 'fs';
+import * as util from 'util';
+
+describe('DocumentsService', () => {
+  let service: DocumentsService;
+  const readFileMock = jest.fn();
+
+  beforeEach(() => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(util, 'promisify').mockReturnValue(readFileMock);
+    service = new DocumentsService();
+  });
+
+  it('should throw a 404 error if the file does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    await expect(service.getFileContent('path/to/nonexistent/file')).rejects.toThrow(
+      new HttpException('File not found', HttpStatus.NOT_FOUND),
+    );
+  });
+
+  it('should return file content if the file exists', async () => {
+    const mockContent = Buffer.from('file content');
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    readFileMock.mockResolvedValue(mockContent);
+
+    const result = await service.getFileContent('path/to/existing/file');
+
+    expect(result).toBe(mockContent);
+    expect(readFileMock).toHaveBeenCalledWith('path/to/existing/file');
+  });
+
+  it('should throw a 500 error if reading the file fails', async () => {
+    const errorMessage = 'Read error';
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    readFileMock.mockRejectedValue(new Error(errorMessage));
+
+    await expect(service.getFileContent('path/to/existing/file')).rejects.toThrow(
+      new HttpException(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR),
+    );
+  });
+});

--- a/src/api/documents/documents.service.ts
+++ b/src/api/documents/documents.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import * as fs from 'fs';
+import * as util from 'util';
+
+@Injectable()
+export class DocumentsService {
+  private readFile = util.promisify(fs.readFile);
+
+  async getFileContent(filePath: string): Promise<Buffer> {
+    if (!fs.existsSync(filePath)) {
+      throw new HttpException('File not found', HttpStatus.NOT_FOUND);
+    }
+
+    try {
+      const fileContent = await this.readFile(filePath);
+      return fileContent;
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,10 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { RuleData, RuleDataSchema } from './api/ruleData/ruleData.schema';
 import { RuleDataController } from './api/ruleData/ruleData.controller';
 import { RuleDataService } from './api/ruleData/ruleData.service';
+import { DecisionsController } from './api/decisions/decisions.controller';
+import { DecisionsService } from './api/decisions/decisions.service';
+import { DocumentsController } from './api/documents/documents.controller';
+import { DocumentsService } from './api/documents/documents.service';
 import { SubmissionsController } from './api/submissions/submissions.controller';
 import { SubmissionsService } from './api/submissions/submissions.service';
 
@@ -11,9 +15,9 @@ import { SubmissionsService } from './api/submissions/submissions.service';
   imports: [
     ConfigModule.forRoot(),
     MongooseModule.forRoot(process.env.MONGODB_URL),
-    MongooseModule.forFeature([{ name: RuleData.name, schema: RuleDataSchema }]), // import model
+    MongooseModule.forFeature([{ name: RuleData.name, schema: RuleDataSchema }]),
   ],
-  controllers: [RuleDataController, SubmissionsController],
-  providers: [RuleDataService, SubmissionsService],
+  controllers: [RuleDataController, DecisionsController, DocumentsController, SubmissionsController],
+  providers: [RuleDataService, DecisionsService, DocumentsService, SubmissionsService],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);


### PR DESCRIPTION
Completed:
- [x] Added ZenEngine implementation
- [x] Added decisions API endpoints
- [x] Added JSON documents API endpoints
- [x] Added first dto for decisions API

_NOTE: This implementation requires that the json rule files live in `src/rules`. None have been directly pushed to this project._

Still to do (either as part of this story or added to backlog):
- [ ] Determine baseline performance of implementation 
- [ ] Implement some better security so these APIs are not publicly accessible anywhere
- [ ] Add documentation for these API endpoints (automate with Swagger?)