### PR TITLE
Test/rules repo

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
       - dev
       - pipeline
+      - test/rules-repo
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
       - pipeline
-  workflow_dispatch:
+  workflow_dispatch: # Allows us to trigger this workflow from elsewhere (like the rules repo)
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev
       - pipeline
-      - test/rules-repo
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -32,9 +32,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Extract current branch name
+        id: extract_branch
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
+          # This is the branch name we want to use of the rules repo branch
+          # We want it to be the same as the branch we are building so they stay in sync
+          RULES_REPO_BRANCH: ${{ env.BRANCH_NAME }}
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Install the app dependencies in a full Node docker image
 FROM registry.access.redhat.com/ubi9/nodejs-20:latest
 
+# Set the environment variables
+ARG RULES_REPO_BRANCH
+ENV RULES_REPO_BRANCH=${RULES_REPO_BRANCH}
+
 # Set the working directory
 WORKDIR /opt/app-root/src
 
@@ -15,9 +19,7 @@ RUN npm ci
 COPY . ./
 
 # Clone the rules repository
-# TODO:  -b ${BRANCH_NAME}
-# TODO: docker build --build-arg BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) -t my-image .
-RUN git clone -b dev https://github.com/bcgov/brms-rules.git rules-repo
+RUN git clone -b ${RULES_REPO_BRANCH} https://github.com/bcgov/brms-rules.git brms-rules
 
 # Start the application
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,10 @@ RUN npm ci
 # Copy the application code
 COPY . ./
 
+# Clone the rules repository
+# TODO:  -b ${BRANCH_NAME}
+# TODO: docker build --build-arg BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) -t my-image .
+RUN git clone -b dev https://github.com/bcgov/brms-rules.git rules-repo
+
 # Start the application
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Before running your application locally, you'll need some environment variables.
 - FRONTEND_URI: The URI for the frontend application. Set it to http://localhost:8080.
 - CHEFS_API_URL: The URL for the Chefs API. Set it to https://submit.digital.gov.bc.ca/app/api/v1.
 
+### Including Rules from the Rules Repository
+
+To get access to rules locally on your machine simply clone the repo at https://github.com/bcgov/brms-rules into your project. This project is set to grab rules from `brms-rules/rules`, which is the default location of rules if that project is cloned into this one.
+
 ### Running the Application
 
 Install dependencies:

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -53,7 +53,7 @@ describe('DecisionsService', () => {
       const content = JSON.stringify({ rule: 'rule' });
       (readFile as jest.Mock).mockResolvedValue(content);
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(readFile).toHaveBeenCalledWith(`src/rules/${ruleFileName}`);
+      expect(readFile).toHaveBeenCalledWith(`rules-repo/rules/${ruleFileName}`);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -1,7 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { DecisionsService, RULES_DIRECTORY } from './decisions.service';
-import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
 import { readFile } from 'fs/promises';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
+import { DecisionsService } from './decisions.service';
 
 jest.mock('fs/promises');
 
@@ -19,7 +20,7 @@ describe('DecisionsService', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DecisionsService, { provide: ZenEngine, useValue: mockEngine }],
+      providers: [ConfigService, DecisionsService, { provide: ZenEngine, useValue: mockEngine }],
     }).compile();
 
     service = module.get<DecisionsService>(DecisionsService);
@@ -53,7 +54,7 @@ describe('DecisionsService', () => {
       const content = JSON.stringify({ rule: 'rule' });
       (readFile as jest.Mock).mockResolvedValue(content);
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(readFile).toHaveBeenCalledWith(`${RULES_DIRECTORY}/${ruleFileName}`);
+      expect(readFile).toHaveBeenCalledWith(`${service.rulesDirectory}/${ruleFileName}`);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -53,7 +53,7 @@ describe('DecisionsService', () => {
       const content = JSON.stringify({ rule: 'rule' });
       (readFile as jest.Mock).mockResolvedValue(content);
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(readFile).toHaveBeenCalledWith(`rules-repo/rules/${ruleFileName}`);
+      expect(readFile).toHaveBeenCalledWith(`brms-rules/rules/${ruleFileName}`);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { DecisionsService } from './decisions.service';
+import { DecisionsService, RULES_DIRECTORY } from './decisions.service';
 import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
 import { readFile } from 'fs/promises';
 
@@ -53,7 +53,7 @@ describe('DecisionsService', () => {
       const content = JSON.stringify({ rule: 'rule' });
       (readFile as jest.Mock).mockResolvedValue(content);
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(readFile).toHaveBeenCalledWith(`brms-rules/rules/${ruleFileName}`);
+      expect(readFile).toHaveBeenCalledWith(`${RULES_DIRECTORY}/${ruleFileName}`);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 import { Injectable } from '@nestjs/common';
 import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
 
-const RULES_DIRECTORY = 'rules-repo/rules';
+const RULES_DIRECTORY = 'brms-rules/rules';
 
 @Injectable()
 export class DecisionsService {

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -1,15 +1,16 @@
 import { readFile } from 'fs/promises';
 import { Injectable } from '@nestjs/common';
 import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
-
-export const RULES_DIRECTORY = 'brms-rules/rules';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class DecisionsService {
   engine: ZenEngine;
+  rulesDirectory: string;
 
-  constructor() {
+  constructor(private configService: ConfigService) {
     this.engine = new ZenEngine();
+    this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
   }
 
   async runDecision(content: object, context: object, options: ZenEvaluateOptions) {
@@ -23,7 +24,7 @@ export class DecisionsService {
 
   async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions) {
     try {
-      const content = await readFile(`${RULES_DIRECTORY}/${ruleFileName}`);
+      const content = await readFile(`${this.rulesDirectory}/${ruleFileName}`);
       return this.runDecision(content, context, options);
     } catch (error) {
       throw new Error(`Failed to run decision: ${error.message}`);

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 import { Injectable } from '@nestjs/common';
 import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
 
-const RULES_DIRECTORY = 'src/rules';
+const RULES_DIRECTORY = 'rules-repo/rules';
 
 @Injectable()
 export class DecisionsService {

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 import { Injectable } from '@nestjs/common';
 import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
 
-const RULES_DIRECTORY = 'brms-rules/rules';
+export const RULES_DIRECTORY = 'brms-rules/rules';
 
 @Injectable()
 export class DecisionsService {

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -8,7 +8,7 @@ export class DocumentsController {
 
   @Get('/:ruleFileName')
   async getRuleFile(@Param('ruleFileName') ruleFileName: string, @Res() res: Response) {
-    const filePath = `src/rules/${ruleFileName}`;
+    const filePath = `rules-repo/rules/${ruleFileName}`;
     const fileContent = await this.documentsService.getFileContent(filePath);
 
     try {

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -6,10 +6,16 @@ import { DocumentsService } from './documents.service';
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
 
+  @Get('/')
+  // Get a list of all the JSON files in the rules directory
+  async getAllDocuments() {
+    return await this.documentsService.getAllJSONFiles();
+  }
+
   @Get('/:ruleFileName')
+  // Get a specific JSON file from the rules directory
   async getRuleFile(@Param('ruleFileName') ruleFileName: string, @Res() res: Response) {
-    const filePath = `brms-rules/rules/${ruleFileName}`;
-    const fileContent = await this.documentsService.getFileContent(filePath);
+    const fileContent = await this.documentsService.getFileContent(ruleFileName);
 
     try {
       res.setHeader('Content-Type', 'application/json');

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -8,7 +8,7 @@ export class DocumentsController {
 
   @Get('/:ruleFileName')
   async getRuleFile(@Param('ruleFileName') ruleFileName: string, @Res() res: Response) {
-    const filePath = `rules-repo/rules/${ruleFileName}`;
+    const filePath = `brms-rules/rules/${ruleFileName}`;
     const fileContent = await this.documentsService.getFileContent(filePath);
 
     try {

--- a/src/api/documents/documents.service.spec.ts
+++ b/src/api/documents/documents.service.spec.ts
@@ -1,4 +1,4 @@
-import { DocumentsService } from './documents.service'; // Adjust the path as needed
+import { DocumentsService, RULES_DIRECTORY } from './documents.service'; // Adjust the path as needed
 import { HttpException, HttpStatus } from '@nestjs/common';
 import * as fs from 'fs';
 import * as util from 'util';
@@ -29,7 +29,7 @@ describe('DocumentsService', () => {
     const result = await service.getFileContent('path/to/existing/file');
 
     expect(result).toBe(mockContent);
-    expect(readFileMock).toHaveBeenCalledWith('path/to/existing/file');
+    expect(readFileMock).toHaveBeenCalledWith(`${RULES_DIRECTORY}/path/to/existing/file`);
   });
 
   it('should throw a 500 error if reading the file fails', async () => {

--- a/src/api/documents/documents.service.spec.ts
+++ b/src/api/documents/documents.service.spec.ts
@@ -1,16 +1,21 @@
-import { DocumentsService, RULES_DIRECTORY } from './documents.service'; // Adjust the path as needed
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
 import * as fs from 'fs';
 import * as util from 'util';
+import { DocumentsService } from './documents.service';
 
 describe('DocumentsService', () => {
   let service: DocumentsService;
   const readFileMock = jest.fn();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.spyOn(fs, 'existsSync').mockReturnValue(false);
     jest.spyOn(util, 'promisify').mockReturnValue(readFileMock);
-    service = new DocumentsService();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ConfigService, DocumentsService],
+    }).compile();
+    service = module.get<DocumentsService>(DocumentsService);
   });
 
   it('should throw a 404 error if the file does not exist', async () => {
@@ -29,7 +34,7 @@ describe('DocumentsService', () => {
     const result = await service.getFileContent('path/to/existing/file');
 
     expect(result).toBe(mockContent);
-    expect(readFileMock).toHaveBeenCalledWith(`${RULES_DIRECTORY}/path/to/existing/file`);
+    expect(readFileMock).toHaveBeenCalledWith(`${service.rulesDirectory}/path/to/existing/file`);
   });
 
   it('should throw a 500 error if reading the file fails', async () => {

--- a/src/api/documents/documents.service.ts
+++ b/src/api/documents/documents.service.ts
@@ -2,16 +2,21 @@ import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as util from 'util';
 import * as path from 'path';
+import { ConfigService } from '@nestjs/config';
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
-
-export const RULES_DIRECTORY = 'brms-rules/rules';
 
 @Injectable()
 export class DocumentsService {
+  rulesDirectory: string;
+
+  constructor(private configService: ConfigService) {
+    this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
+  }
+
   private readFile = util.promisify(fs.readFile);
 
   // Go through the rules directory and return a list of all JSON files
-  async getAllJSONFiles(directory: string = RULES_DIRECTORY): Promise<string[]> {
+  async getAllJSONFiles(directory: string = this.rulesDirectory): Promise<string[]> {
     const jsonFiles: string[] = [];
 
     async function readDirectory(dir: string, baseDir: string) {
@@ -37,7 +42,7 @@ export class DocumentsService {
 
   // Get the content of a specific JSON file
   async getFileContent(ruleFileName: string): Promise<Buffer> {
-    const filePath = `${RULES_DIRECTORY}/${ruleFileName}`;
+    const filePath = `${this.rulesDirectory}/${ruleFileName}`;
     if (!fs.existsSync(filePath)) {
       throw new HttpException('File not found', HttpStatus.NOT_FOUND);
     }

--- a/src/api/documents/documents.service.ts
+++ b/src/api/documents/documents.service.ts
@@ -1,12 +1,43 @@
-import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as util from 'util';
+import * as path from 'path';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+
+export const RULES_DIRECTORY = 'brms-rules/rules';
 
 @Injectable()
 export class DocumentsService {
   private readFile = util.promisify(fs.readFile);
 
-  async getFileContent(filePath: string): Promise<Buffer> {
+  // Go through the rules directory and return a list of all JSON files
+  async getAllJSONFiles(directory: string = RULES_DIRECTORY): Promise<string[]> {
+    const jsonFiles: string[] = [];
+
+    async function readDirectory(dir: string, baseDir: string) {
+      const files = await fsPromises.readdir(dir, { withFileTypes: true });
+      for (const file of files) {
+        const fullPath = path.join(dir, file.name);
+        const relativePath = path.relative(baseDir, fullPath);
+        if (file.isDirectory()) {
+          await readDirectory(fullPath, baseDir); // Recurse into subdirectory
+        } else if (path.extname(file.name).toLowerCase() === '.json') {
+          jsonFiles.push(relativePath);
+        }
+      }
+    }
+
+    try {
+      await readDirectory(directory, directory);
+      return jsonFiles;
+    } catch (err) {
+      throw new HttpException('Error reading directory', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  // Get the content of a specific JSON file
+  async getFileContent(ruleFileName: string): Promise<Buffer> {
+    const filePath = `${RULES_DIRECTORY}/${ruleFileName}`;
     if (!fs.existsSync(filePath)) {
       throw new HttpException('File not found', HttpStatus.NOT_FOUND);
     }

--- a/src/api/ruleData/ruleData.service.ts
+++ b/src/api/ruleData/ruleData.service.ts
@@ -30,10 +30,14 @@ export class RuleDataService {
 
   async createRuleData(ruleData: RuleData): Promise<RuleData> {
     try {
+      if (!ruleData._id) {
+        ruleData._id = new Date().getTime().toString();
+      }
       const newRuleData = new this.ruleDataModel(ruleData);
       const response = await newRuleData.save();
       return response;
     } catch (error) {
+      console.error(error.message);
       throw new Error(`Failed to add rule data: ${error.message}`);
     }
   }

--- a/src/api/ruleData/ruleData.service.ts
+++ b/src/api/ruleData/ruleData.service.ts
@@ -1,6 +1,7 @@
+import { ObjectId } from 'mongodb';
+import { Model } from 'mongoose';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
 import { RuleData, RuleDataDocument } from './ruleData.schema';
 
 @Injectable()
@@ -31,7 +32,8 @@ export class RuleDataService {
   async createRuleData(ruleData: RuleData): Promise<RuleData> {
     try {
       if (!ruleData._id) {
-        ruleData._id = new Date().getTime().toString();
+        const newRuleID = new ObjectId();
+        ruleData._id = newRuleID.toHexString();
       }
       const newRuleData = new this.ruleDataModel(ruleData);
       const response = await newRuleData.save();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,7 +13,14 @@ import { SubmissionsService } from './api/submissions/submissions.service';
 
 @Module({
   imports: [
-    ConfigModule.forRoot(),
+    ConfigModule.forRoot({
+      isGlobal: true, // Make the ConfigModule globally available
+      load: [
+        () => ({
+          RULES_DIRECTORY: process.env.RULES_DIRECTORY || 'brms-rules/rules',
+        }),
+      ],
+    }),
     MongooseModule.forRoot(process.env.MONGODB_URL),
     MongooseModule.forFeature([{ name: RuleData.name, schema: RuleDataSchema }]),
   ],


### PR DESCRIPTION
- [x] Updated Dockerfile so that json files from rules repo will be copied over before being deployed
- [x] Updated where the api looks for json file rules
- [x] Added workflow_dispatch so this workflow can be called from rules repo (in order to re-deploy when rules added)

This works with https://github.com/bcgov/brms-rules/pull/6
It also supports https://github.com/bcgov/brms-simulator-frontend/pull/5