### PR TITLE
Add functionality to sync db with new rules in rules repo upon startup

### DIFF
--- a/src/api/ruleData/ruleData.service.spec.ts
+++ b/src/api/ruleData/ruleData.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
+import { DocumentsService } from '../documents/documents.service';
 import { RuleDataService } from './ruleData.service';
 import { RuleData } from './ruleData.schema';
 
@@ -24,10 +25,17 @@ export const mockServiceProviders = [
       })),
     }),
   },
+  {
+    provide: DocumentsService,
+    useValue: {
+      getAllJSONFiles: jest.fn().mockResolvedValue(['doc1.json', 'doc2.json']),
+    },
+  },
 ];
 
 describe('RuleDataService', () => {
   let service: RuleDataService;
+  let documentsService: DocumentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -35,6 +43,7 @@ describe('RuleDataService', () => {
     }).compile();
 
     service = module.get<RuleDataService>(RuleDataService);
+    documentsService = module.get<DocumentsService>(DocumentsService);
   });
 
   it('should be defined', () => {
@@ -48,5 +57,19 @@ describe('RuleDataService', () => {
 
   it('should get data for a rule', async () => {
     expect(await service.getRuleData(mockRuleData._id)).toEqual(mockRuleData);
+  });
+
+  it('should add unsynced files correctly', async () => {
+    // Mock the expected behavior getting db files, getting repo files, and adding to db
+    const unsyncedFiles = ['file1.txt', 'file2.txt'];
+    jest.spyOn(service, 'getAllRuleData').mockResolvedValue([mockRuleData]);
+    jest.spyOn(documentsService, 'getAllJSONFiles').mockResolvedValue(unsyncedFiles);
+    jest.spyOn(service, 'createRuleData').mockImplementation((file: RuleData) => Promise.resolve(file));
+
+    await service.addUnsyncedFiles();
+
+    expect(service.createRuleData).toHaveBeenCalled();
+    expect(documentsService.getAllJSONFiles).toHaveBeenCalled();
+    expect(service.createRuleData).toHaveBeenCalledTimes(unsyncedFiles.length);
   });
 });


### PR DESCRIPTION
- [x] Add functionality to sync db with new rules in rules repo upon startup

Question: should rules that have been removed from the repo be removed here as well? Might be a future task - set them to inactive or something like that.