### PR TITLE
Fix handling of undefined items.

### DIFF
--- a/src/utils/handleTrace.ts
+++ b/src/utils/handleTrace.ts
@@ -51,10 +51,7 @@ export const mapTraceToResult = (trace: TraceObject, ruleSchema: RuleSchema, typ
       result[property] = value;
     } else {
       // Direct match without id
-      const directMatch = schema.find(
-        (item: any) =>
-          item.property !== undefined && item.property !== null && replaceSpecialCharacters(item.property, '') === key,
-      );
+      const directMatch = schema.find((item: any) => replaceSpecialCharacters(item.property ?? '', '') === key);
       if (directMatch) {
         const formattedKey = replaceSpecialCharacters(directMatch.property, '');
         result[formattedKey] = value;

--- a/src/utils/handleTrace.ts
+++ b/src/utils/handleTrace.ts
@@ -51,7 +51,10 @@ export const mapTraceToResult = (trace: TraceObject, ruleSchema: RuleSchema, typ
       result[property] = value;
     } else {
       // Direct match without id
-      const directMatch = schema.find((item: any) => replaceSpecialCharacters(item.property, '') === key);
+      const directMatch = schema.find(
+        (item: any) =>
+          item.property !== undefined && item.property !== null && replaceSpecialCharacters(item.property, '') === key,
+      );
       if (directMatch) {
         const formattedKey = replaceSpecialCharacters(directMatch.property, '');
         result[formattedKey] = value;


### PR DESCRIPTION
Critical bug encountered when users do not specify a 'selector' in the jdm rule editor table column.

When a user attempts to save a scenario, the generated rule schema includes these undefined values. These undefined values were not being handled in string replacement, and were causing a crash.