### PR TITLE
Add proxy server to query klamm by field name

### DIFF
--- a/src/api/klamm/klamm.controller.spec.ts
+++ b/src/api/klamm/klamm.controller.spec.ts
@@ -7,7 +7,6 @@ describe('KlammController', () => {
   let service: KlammService;
 
   beforeEach(async () => {
-    // Mock KlammService
     const module: TestingModule = await Test.createTestingModule({
       controllers: [KlammController],
       providers: [
@@ -15,6 +14,7 @@ describe('KlammController', () => {
           provide: KlammService,
           useValue: {
             getBREFields: jest.fn(() => Promise.resolve('expected result')),
+            getBREFieldFromName: jest.fn((fieldName) => Promise.resolve(`result for ${fieldName}`)), // Mock implementation
           },
         },
       ],
@@ -27,5 +27,12 @@ describe('KlammController', () => {
   it('should call getBREFields and return expected result', async () => {
     expect(await controller.getBREFields()).toBe('expected result');
     expect(service.getBREFields).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call getBREFieldFromName with fieldName and return expected result', async () => {
+    const fieldName = 'testField';
+    expect(await controller.getBREFieldFromName(fieldName)).toBe(`result for ${fieldName}`);
+    expect(service.getBREFieldFromName).toHaveBeenCalledWith(fieldName);
+    expect(service.getBREFieldFromName).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/klamm/klamm.controller.ts
+++ b/src/api/klamm/klamm.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { KlammService } from './klamm.service';
 
 @Controller('api/klamm')
@@ -8,5 +8,10 @@ export class KlammController {
   @Get('/brefields')
   async getBREFields() {
     return await this.klammService.getBREFields();
+  }
+
+  @Get('/brefield/:fieldName')
+  async getBREFieldFromName(@Param('fieldName') fieldName: string) {
+    return await this.klammService.getBREFieldFromName(fieldName);
   }
 }

--- a/src/api/klamm/klamm.service.ts
+++ b/src/api/klamm/klamm.service.ts
@@ -1,18 +1,46 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
+
+export class InvalidFieldRequest extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidFieldRequestError';
+  }
+}
 
 @Injectable()
 export class KlammService {
+  axiosKlammInstance: AxiosInstance;
+
+  constructor() {
+    this.axiosKlammInstance = axios.create({
+      headers: { Authorization: `Bearer ${process.env.KLAMM_API_AUTH_TOKEN}`, 'Content-Type': 'application/json' },
+    });
+  }
+
   async getBREFields(): Promise<string[]> {
     try {
-      const { data } = await axios.get(`${process.env.KLAMM_API_URL}/api/brefields`, {
-        headers: {
-          Authorization: `Bearer ${process.env.KLAMM_API_AUTH_TOKEN}`,
-          'Content-Type': 'application/json',
-        },
-      });
+      const { data } = await this.axiosKlammInstance.get(`${process.env.KLAMM_API_URL}/api/brefields`);
       return data;
     } catch (err) {
+      throw new HttpException('Error fetching from Klamm', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async getBREFieldFromName(fieldName: string): Promise<any[]> {
+    try {
+      const { data } = await this.axiosKlammInstance.get(`${process.env.KLAMM_API_URL}/api/brefields`, {
+        params: { name: fieldName },
+      });
+      if (!data?.data || data.data.length < 1) {
+        throw new InvalidFieldRequest('Field name does not exist');
+      }
+      // Just gets first instance of a field - we shouldn't have multiple with the same name, although ideally we would make sure of that
+      return data.data[0];
+    } catch (error) {
+      if (error instanceof InvalidFieldRequest) {
+        throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+      }
       throw new HttpException('Error fetching from Klamm', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }


### PR DESCRIPTION
- [x] Add proxy server to query klamm by field name

NOTE: I have decided to query by field name, rather than id. This makes the system work better with the frontend, but in some other ways not ideal. Wonder if we could make the name a ~~primary~~ _unique_ key as well?