### PR TITLE
Fix missed update for child_fields formatting to childFields.

### DIFF
--- a/src/api/ruleMapping/ruleMapping.interface.ts
+++ b/src/api/ruleMapping/ruleMapping.interface.ts
@@ -12,6 +12,7 @@ export interface Field {
   validationCriteria?: string;
   validationType?: string;
   child_fields?: Field[] | RuleField[];
+  childFields?: Field[] | RuleField[];
 }
 
 export interface InputField extends Field {}

--- a/src/api/ruleMapping/ruleMapping.service.ts
+++ b/src/api/ruleMapping/ruleMapping.service.ts
@@ -240,7 +240,7 @@ export class RuleMappingService {
         type: field.dataType,
         validationCriteria: field.validationCriteria,
         validationType: field.validationType,
-        childFields: field.child_fields,
+        childFields: field.childFields,
       }));
 
     // Extract inputs from 'inputNode' type


### PR DESCRIPTION
Missed update to the childFields format when doing bulk updates away from child_fields. This fixes the issue where it wasn't properly mapping some nested fields due to this naming difference.