### PR TITLE
Update all uses of 'goRulesJSONFilename' to 'filepath' and adds 'name'

### DIFF
--- a/src/api/ruleData/ruleData.schema.ts
+++ b/src/api/ruleData/ruleData.schema.ts
@@ -7,11 +7,14 @@ export class RuleData {
   @Prop({ required: true, description: 'The GoRules ID' })
   _id: string;
 
+  @Prop({ unique: true, description: 'A unique name currently derived from the filepath' })
+  name: string;
+
   @Prop({ description: 'The title of the rule' })
   title: string;
 
-  @Prop({ required: true, description: 'The filename of the JSON file containing the rule' })
-  goRulesJSONFilename: string;
+  @Prop({ required: true, description: 'The filepath of the JSON file containing the rule' })
+  filepath: string;
 
   @Prop({ type: Types.ObjectId, description: 'Draft of updated rule content', ref: 'RuleDraft' })
   ruleDraft?: RuleDraftDocument | Types.ObjectId;
@@ -21,6 +24,10 @@ export class RuleData {
 
   @Prop({ description: 'If the rule has been published' })
   isPublished?: boolean;
+
+  // TODO: REMOVE AFTER MIGRATIONS ALL COMPLETE
+  @Prop({ description: 'This is being deprecated' })
+  goRulesJSONFilename?: string;
 }
 
 export type RuleDataDocument = RuleData & Document;

--- a/src/api/ruleData/ruleData.service.spec.ts
+++ b/src/api/ruleData/ruleData.service.spec.ts
@@ -8,8 +8,9 @@ import axios from 'axios';
 
 export const mockRuleData = {
   _id: 'testId',
+  name: 'title',
   title: 'Title',
-  goRulesJSONFilename: 'filename.json',
+  filepath: 'title.json',
 };
 const mockRuleDraft = { content: { nodes: [], edges: [] } };
 
@@ -98,20 +99,23 @@ describe('RuleDataService', () => {
   it('should correctly remove inReview statuses when branches no longer exist', async () => {
     const ruleWithBranchToRemove: RuleData = {
       _id: 'testId1',
+      name: 'title1',
       title: 'Title 1',
-      goRulesJSONFilename: 'filename1.json',
+      filepath: 'title1.json',
       reviewBranch: 'myoldbranch',
     };
     const ruleWithBranchToKeep: RuleData = {
       _id: 'testId2',
+      name: 'title2',
       title: 'Title 2',
-      goRulesJSONFilename: 'filename2.json',
+      filepath: 'title2.json',
       reviewBranch: 'branch2',
     };
     const ruleWithoutBranch: RuleData = {
       _id: 'testId3',
+      name: 'title3',
       title: 'Title 3',
-      goRulesJSONFilename: 'filename3.json',
+      filepath: 'path/title3.json',
     };
     const mockedbranches = { data: [{ name: 'branch1' }, { name: ruleWithBranchToKeep.reviewBranch }] };
     jest.spyOn(axios, 'get').mockResolvedValue(mockedbranches);
@@ -137,7 +141,7 @@ describe('RuleDataService', () => {
   });
 
   it('should handle adding duplicate files gracefully', async () => {
-    const unsyncedFiles = ['file1.txt', mockRuleData.goRulesJSONFilename];
+    const unsyncedFiles = ['file1.txt', mockRuleData.filepath];
     jest.spyOn(documentsService, 'getAllJSONFiles').mockResolvedValue(unsyncedFiles);
     jest.spyOn(service, 'createRuleData').mockImplementation((rData: RuleData) => Promise.resolve(rData));
     jest

--- a/src/api/ruleMapping/ruleMapping.controller.ts
+++ b/src/api/ruleMapping/ruleMapping.controller.ts
@@ -10,7 +10,7 @@ export class RuleMappingController {
   // Map a rule file to its unique inputs, and all outputs
   @Post('/')
   async getRuleSchema(
-    @Body('goRulesJSONFilename') goRulesJSONFilename: string,
+    @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: EvaluateRuleMappingDto,
     @Res() res: Response,
   ) {
@@ -18,7 +18,7 @@ export class RuleMappingController {
 
     try {
       res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Content-Disposition', `attachment; filename=${goRulesJSONFilename}`);
+      res.setHeader('Content-Disposition', `attachment; filename=${filepath}`);
       res.send(rulemap);
     } catch (error) {
       if (error instanceof InvalidRuleContent) {

--- a/src/api/scenarioData/dto/create-scenario.dto.ts
+++ b/src/api/scenarioData/dto/create-scenario.dto.ts
@@ -28,5 +28,5 @@ export class CreateScenarioDto {
 
   @IsNotEmpty()
   @IsString()
-  goRulesJSONFilename: string;
+  filepath: string;
 }

--- a/src/api/scenarioData/scenarioData.controller.spec.ts
+++ b/src/api/scenarioData/scenarioData.controller.spec.ts
@@ -110,7 +110,7 @@ describe('ScenarioDataController', () => {
         title: 'title',
         ruleID: 'ruleID',
         variables: [],
-        goRulesJSONFilename: 'filename',
+        filepath: 'filename',
         expectedResults: [],
       };
 
@@ -127,7 +127,7 @@ describe('ScenarioDataController', () => {
         title: result.title,
         ruleID: result.ruleID,
         variables: variables,
-        goRulesJSONFilename: result.goRulesJSONFilename,
+        filepath: result.filepath,
         expectedResults: expectedResults,
       };
 
@@ -142,7 +142,7 @@ describe('ScenarioDataController', () => {
         title: 'title',
         ruleID: 'ruleID',
         variables: [],
-        goRulesJSONFilename: 'filename',
+        filepath: 'filename',
         expectedResults: [],
       };
 
@@ -156,7 +156,7 @@ describe('ScenarioDataController', () => {
         title: 'title',
         ruleID: 'ruleID',
         variables: [],
-        goRulesJSONFilename: 'filename',
+        filepath: 'filename',
         expectedResults: [],
       };
 
@@ -166,7 +166,7 @@ describe('ScenarioDataController', () => {
         title: result.title,
         ruleID: result.ruleID,
         variables: [],
-        goRulesJSONFilename: result.goRulesJSONFilename,
+        filepath: result.filepath,
         expectedResults: [],
       };
 
@@ -181,7 +181,7 @@ describe('ScenarioDataController', () => {
         title: 'title',
         ruleID: 'ruleID',
         variables: [],
-        goRulesJSONFilename: 'filename',
+        filepath: 'filename',
         expectedResults: [],
       };
 
@@ -205,7 +205,7 @@ describe('ScenarioDataController', () => {
 
   describe('getCSVForRuleRun', () => {
     it('should return CSV content with correct headers', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const csvContent = `Scenario,Input: familyComposition,Input: numberOfChildren,Output: isEligible,Output: baseAmount
 Scenario 1,single,,true,
@@ -219,20 +219,20 @@ Scenario 2,couple,3,,200`;
         setHeader: jest.fn(),
       };
 
-      await controller.getCSVForRuleRun(goRulesJSONFilename, ruleContent, mockResponse as any);
+      await controller.getCSVForRuleRun(filepath, ruleContent, mockResponse as any);
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
       expect(mockResponse.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv');
       expect(mockResponse.setHeader).toHaveBeenCalledWith(
         'Content-Disposition',
-        `attachment; filename=${goRulesJSONFilename.replace(/\.json$/, '.csv')}`,
+        `attachment; filename=${filepath.replace(/\.json$/, '.csv')}`,
       );
       expect(mockResponse.send).toHaveBeenCalledWith(csvContent);
     });
 
     it('should throw an error if service fails', async () => {
       const errorMessage = 'Error generating CSV for rule run';
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       jest.spyOn(service, 'getCSVForRuleRun').mockRejectedValue(new Error(errorMessage));
 
@@ -242,11 +242,11 @@ Scenario 2,couple,3,,200`;
       };
 
       await expect(async () => {
-        await controller.getCSVForRuleRun(goRulesJSONFilename, ruleContent, mockResponse as any);
+        await controller.getCSVForRuleRun(filepath, ruleContent, mockResponse as any);
       }).rejects.toThrow(Error);
 
       try {
-        await controller.getCSVForRuleRun(goRulesJSONFilename, ruleContent, mockResponse as any);
+        await controller.getCSVForRuleRun(filepath, ruleContent, mockResponse as any);
       } catch (error) {
         expect(error.message).toBe('Error generating CSV for rule run');
       }
@@ -292,7 +292,7 @@ Scenario 2,couple,3,,200`;
           title: 'Scenario 1',
           ruleID: '',
           variables: [{ name: 'Age', value: 25, type: 'number' }],
-          goRulesJSONFilename: 'test.json',
+          filepath: 'test.json',
         },
       ];
 

--- a/src/api/scenarioData/scenarioData.schema.ts
+++ b/src/api/scenarioData/scenarioData.schema.ts
@@ -57,7 +57,7 @@ export class ScenarioData {
   expectedResults: Variable[];
 
   @Prop({ required: true, description: 'The filename of the JSON file containing the rule' })
-  goRulesJSONFilename: string;
+  filepath: string;
 }
 
 export const ScenarioDataSchema = SchemaFactory.createForClass(ScenarioData);

--- a/src/api/scenarioData/scenarioData.service.spec.ts
+++ b/src/api/scenarioData/scenarioData.service.spec.ts
@@ -24,7 +24,7 @@ describe('ScenarioDataService', () => {
     title: 'Test Title',
     ruleID: 'ruleID',
     variables: [],
-    goRulesJSONFilename: 'test.json',
+    filepath: 'test.json',
     expectedResults: [],
   };
 
@@ -266,19 +266,19 @@ describe('ScenarioDataService', () => {
 
   describe('getScenariosByFilename', () => {
     it('should return scenarios by filename', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const scenarioDataList: ScenarioData[] = [mockScenarioData];
-      scenarioDataList[0].goRulesJSONFilename = goRulesJSONFilename;
+      scenarioDataList[0].filepath = filepath;
       MockScenarioDataModel.find = jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(scenarioDataList) });
 
-      const result = await service.getScenariosByFilename(goRulesJSONFilename);
+      const result = await service.getScenariosByFilename(filepath);
 
       expect(result).toEqual(scenarioDataList);
-      expect(MockScenarioDataModel.find).toHaveBeenCalledWith({ goRulesJSONFilename: { $eq: goRulesJSONFilename } });
+      expect(MockScenarioDataModel.find).toHaveBeenCalledWith({ filepath: { $eq: filepath } });
     });
 
     it('should throw an error if an error occurs while retrieving scenarios by filename', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const errorMessage = 'DB Error';
 
       MockScenarioDataModel.find = jest
@@ -286,15 +286,15 @@ describe('ScenarioDataService', () => {
         .mockReturnValue({ exec: jest.fn().mockRejectedValue(new Error(errorMessage)) });
 
       await expect(async () => {
-        await service.getScenariosByFilename(goRulesJSONFilename);
+        await service.getScenariosByFilename(filepath);
       }).rejects.toThrowError(`Error getting scenarios by filename: ${errorMessage}`);
 
-      expect(MockScenarioDataModel.find).toHaveBeenCalledWith({ goRulesJSONFilename: { $eq: goRulesJSONFilename } });
+      expect(MockScenarioDataModel.find).toHaveBeenCalledWith({ filepath: { $eq: filepath } });
     });
   });
   describe('runDecisionsForScenarios', () => {
     it('should run decisions for scenarios and map inputs/outputs correctly', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = {
         nodes: [
           {
@@ -326,7 +326,7 @@ describe('ScenarioDataService', () => {
           title: 'Scenario 1',
           variables: [{ name: 'familyComposition', value: 'single' }],
           ruleID: 'ruleID',
-          goRulesJSONFilename: 'test.json',
+          filepath: 'test.json',
           expectedResults: [],
         },
         {
@@ -334,7 +334,7 @@ describe('ScenarioDataService', () => {
           title: 'Scenario 2',
           variables: [{ name: 'numberOfChildren', value: 2 }],
           ruleID: 'ruleID',
-          goRulesJSONFilename: 'test.json',
+          filepath: 'test.json',
           expectedResults: [],
         },
       ];
@@ -373,7 +373,7 @@ describe('ScenarioDataService', () => {
       jest.spyOn(ruleMappingService, 'ruleSchema').mockResolvedValue(ruleSchemaOutput);
       jest.spyOn(decisionsService, 'runDecisionByContent').mockResolvedValue(decisionResult);
 
-      const results = await service.runDecisionsForScenarios(goRulesJSONFilename, ruleContent);
+      const results = await service.runDecisionsForScenarios(filepath, ruleContent);
 
       expect(results).toEqual({
         'Scenario 1': {
@@ -397,7 +397,7 @@ describe('ScenarioDataService', () => {
       });
     });
     it('should handle errors in decision execution', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const scenarios = [
         {
@@ -405,7 +405,7 @@ describe('ScenarioDataService', () => {
           title: 'Scenario 1',
           variables: [{ name: 'familyComposition', value: 'single' }],
           ruleID: 'ruleID',
-          goRulesJSONFilename: 'test.json',
+          filepath: 'test.json',
           expectedResults: [],
         },
       ];
@@ -419,14 +419,14 @@ describe('ScenarioDataService', () => {
       jest.spyOn(ruleMappingService, 'ruleSchema').mockResolvedValue(ruleSchema);
       jest.spyOn(decisionsService, 'runDecisionByContent').mockRejectedValue(new Error('Decision execution error'));
 
-      const results = await service.runDecisionsForScenarios(goRulesJSONFilename, ruleContent);
+      const results = await service.runDecisionsForScenarios(filepath, ruleContent);
       expect(results).toEqual({
         [testObjectId.toString()]: { error: 'Decision execution error' },
       });
     });
 
     it('should handle scenarios with no variables', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const scenarios = [
         {
@@ -434,7 +434,7 @@ describe('ScenarioDataService', () => {
           title: 'Scenario 1',
           variables: [],
           ruleID: 'ruleID',
-          goRulesJSONFilename: 'test.json',
+          filepath: 'test.json',
           expectedResults: [],
         },
       ];
@@ -460,7 +460,7 @@ describe('ScenarioDataService', () => {
       jest.spyOn(ruleMappingService, 'ruleSchema').mockResolvedValue(ruleSchema);
       jest.spyOn(decisionsService, 'runDecisionByContent').mockResolvedValue(decisionResult);
 
-      const results = await service.runDecisionsForScenarios(goRulesJSONFilename, ruleContent);
+      const results = await service.runDecisionsForScenarios(filepath, ruleContent);
 
       expect(results).toEqual({
         'Scenario 1': {
@@ -478,7 +478,7 @@ describe('ScenarioDataService', () => {
 
   describe('getCSVForRuleRun', () => {
     it('should generate a CSV with correct headers and data', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {
         'Scenario 1': {
@@ -497,7 +497,7 @@ describe('ScenarioDataService', () => {
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,2\nScenario 2,Fail,couple,3`;
 
@@ -505,7 +505,7 @@ describe('ScenarioDataService', () => {
     });
 
     it('should generate a CSV with missing inputs/outputs filled as empty strings', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {
         'Scenario 1': {
@@ -522,7 +522,7 @@ describe('ScenarioDataService', () => {
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,\nScenario 2,Fail,couple,3`;
 
@@ -530,7 +530,7 @@ describe('ScenarioDataService', () => {
     });
 
     it('should generate a CSV with only one scenario', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {
         'Scenario 1': {
@@ -542,7 +542,7 @@ describe('ScenarioDataService', () => {
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,2`;
 
@@ -550,13 +550,13 @@ describe('ScenarioDataService', () => {
     });
 
     it('should generate an empty CSV if no scenarios are present', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {};
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail)`;
 
@@ -564,7 +564,7 @@ describe('ScenarioDataService', () => {
     });
 
     it('should handle scenarios with no variables or outputs', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {
         'Scenario 1': {
@@ -575,7 +575,7 @@ describe('ScenarioDataService', () => {
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail)\nScenario 1,Fail`;
 
@@ -583,7 +583,7 @@ describe('ScenarioDataService', () => {
     });
 
     it('should escape inputs and outputs containing commas or quotes', async () => {
-      const goRulesJSONFilename = 'test.json';
+      const filepath = 'test.json';
       const ruleContent = { nodes: [], edges: [] };
       const ruleRunResults = {
         'Scenario 1': {
@@ -595,7 +595,7 @@ describe('ScenarioDataService', () => {
 
       jest.spyOn(service, 'runDecisionsForScenarios').mockResolvedValue(ruleRunResults);
 
-      const csvContent = await service.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
+      const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
       const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: input1,Input: input2\nScenario 1,Fail,"value, with, commas",value "with" quotes`;
 
@@ -626,12 +626,12 @@ describe('ScenarioDataService', () => {
       expect(result[0]).toMatchObject({
         title: 'Scenario 1',
         ruleID: '',
-        goRulesJSONFilename: 'test.json',
+        filepath: 'test.json',
       });
       expect(result[1]).toMatchObject({
         title: 'Scenario 2',
         ruleID: '',
-        goRulesJSONFilename: 'test.json',
+        filepath: 'test.json',
       });
 
       expect(result[0]).toHaveProperty('variables');

--- a/src/api/scenarioData/scenarioData.service.ts
+++ b/src/api/scenarioData/scenarioData.service.ts
@@ -86,9 +86,9 @@ export class ScenarioDataService {
     }
   }
 
-  async getScenariosByFilename(goRulesJSONFilename: string): Promise<ScenarioData[]> {
+  async getScenariosByFilename(filepath: string): Promise<ScenarioData[]> {
     try {
-      return await this.scenarioDataModel.find({ goRulesJSONFilename: { $eq: goRulesJSONFilename } }).exec();
+      return await this.scenarioDataModel.find({ filepath: { $eq: filepath } }).exec();
     } catch (error) {
       throw new Error(`Error getting scenarios by filename: ${error.message}`);
     }
@@ -100,13 +100,13 @@ export class ScenarioDataService {
    * Maps inputs and outputs from decision traces to structured results.
    */
   async runDecisionsForScenarios(
-    goRulesJSONFilename: string,
+    filepath: string,
     ruleContent?: RuleContent,
     newScenarios?: ScenarioData[],
   ): Promise<{ [scenarioId: string]: any }> {
-    const scenarios = newScenarios || (await this.getScenariosByFilename(goRulesJSONFilename));
+    const scenarios = newScenarios || (await this.getScenariosByFilename(filepath));
     if (!ruleContent) {
-      const fileContent = await this.documentsService.getFileContent(goRulesJSONFilename);
+      const fileContent = await this.documentsService.getFileContent(filepath);
       ruleContent = await JSON.parse(fileContent.toString());
     }
     const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleContent);
@@ -119,7 +119,7 @@ export class ScenarioDataService {
       try {
         const decisionResult = await this.decisionsService.runDecision(
           ruleContent,
-          goRulesJSONFilename,
+          filepath,
           formattedVariablesObject,
           {
             trace: true,
@@ -153,16 +153,8 @@ export class ScenarioDataService {
    * Retrieves scenario results, extracts unique input and output keys, and maps them to CSV rows.
    * Constructs CSV headers and rows based on input and output keys.
    */
-  async getCSVForRuleRun(
-    goRulesJSONFilename: string,
-    ruleContent: RuleContent,
-    newScenarios?: ScenarioData[],
-  ): Promise<string> {
-    const ruleRunResults: RuleRunResults = await this.runDecisionsForScenarios(
-      goRulesJSONFilename,
-      ruleContent,
-      newScenarios,
-    );
+  async getCSVForRuleRun(filepath: string, ruleContent: RuleContent, newScenarios?: ScenarioData[]): Promise<string> {
+    const ruleRunResults: RuleRunResults = await this.runDecisionsForScenarios(filepath, ruleContent, newScenarios);
 
     const keys = {
       inputs: extractUniqueKeys(ruleRunResults, 'inputs'),
@@ -206,14 +198,11 @@ export class ScenarioDataService {
 
   /**
    * Processes a CSV file containing scenario data and returns an array of ScenarioData objects based on the inputs.
-   * @param goRulesJSONFilename The name of the Go rules JSON file.
+   * @param filepath The name of the Go rules JSON file.
    * @param csvContent The CSV file content.
    * @returns An array of ScenarioData objects.
    */
-  async processProvidedScenarios(
-    goRulesJSONFilename: string,
-    csvContent: Express.Multer.File,
-  ): Promise<ScenarioData[]> {
+  async processProvidedScenarios(filepath: string, csvContent: Express.Multer.File): Promise<ScenarioData[]> {
     const parsedData = await parseCSV(csvContent);
     if (!parsedData || parsedData.length === 0) {
       throw new Error('CSV content is empty or invalid');
@@ -237,7 +226,7 @@ export class ScenarioDataService {
         title: scenarioTitle,
         ruleID: '',
         variables: inputs,
-        goRulesJSONFilename: goRulesJSONFilename,
+        filepath: filepath,
         expectedResults: expectedResults,
       };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
+// TODO: Remove this once it has run on prod
+import filepathMigration from './migrations/filepath-migration';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -8,6 +10,10 @@ async function bootstrap() {
     origin: process.env.FRONTEND_URI,
   });
   const port = process.env.PORT || 3000;
+  // TODO: Remove this call once it has run on prod
+  if (process.env.NODE_ENV !== 'test') {
+    filepathMigration();
+  }
   await app.listen(process.env.PORT || 3000);
   console.log(`Server is running on port ${port} with ${process.env.FRONTEND_URI} allowed origins.`);
 }

--- a/src/migrations/filepath-migration.ts
+++ b/src/migrations/filepath-migration.ts
@@ -1,0 +1,40 @@
+/**
+ * MIGRATION
+ * This file is to migrate the RuleData property 'goRulesJSONFilename' to 'filepath'
+ * If also introduces the 'name' property that is derived from the 'goRulesJSONFile'/'filePath' property
+ */
+
+import { connect, connection, model } from 'mongoose';
+import { RuleDataDocument, RuleDataSchema } from '../api/ruleData/ruleData.schema';
+import { deriveNameFromFilepath } from '../utils/helpers';
+
+const RuleData = model<RuleDataDocument>('RuleData', RuleDataSchema);
+
+export default async function filepathMigration() {
+  await connect(process.env.MONGODB_URL);
+
+  try {
+    const documents = await RuleData.find();
+
+    for (const doc of documents) {
+      if (!doc.filepath) {
+        if (doc?.goRulesJSONFilename) {
+          // Update the to have filepath and name
+          doc.filepath = doc.goRulesJSONFilename;
+          doc.name = deriveNameFromFilepath(doc.goRulesJSONFilename);
+          doc.goRulesJSONFilename = undefined;
+          await doc.save();
+          console.log('Updated:', doc);
+        } else {
+          console.warn('WARNING: document exists without goRulesJSONFilename', doc);
+        }
+      }
+    }
+
+    console.log('Filepath migration completed successfully');
+  } catch (error) {
+    console.error('Filepath migration failed', error);
+  } finally {
+    connection.close();
+  }
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -107,3 +107,12 @@ export const formatValue = (value: string): boolean | number | string | null => 
   }
   return value;
 };
+
+/**
+ * Gets the "name" from the filepath
+ * @param filepath
+ * @returns The name
+ */
+export const deriveNameFromFilepath = (filepath: string): string => {
+  return filepath.split('/').pop().replace('.json', '');
+};


### PR DESCRIPTION
- [x] Update all uses of 'goRulesJSONFilename' to 'filepath'
- [x] Introduces the 'name' property that is derived from the 'goRulesJSONFile'/'filePath' property
- [x] Adds temporary migration script that will migrate existing documents to use this new naming
- [x] Temporary migration script will be run when the pod starts up