### PR TITLE
Generate Scenarios for isolation testing of rules.

### DIFF
--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -120,9 +120,12 @@ export class ScenarioDataController {
   ) {
     try {
       const fileContent = await this.scenarioDataService.getCSVForRuleRun(goRulesJSONFilename, ruleContent);
-      res.setHeader('Content-Type', 'text/csv');
+      // UTF- 8 encoding with BOM
+      const bom = '\uFEFF';
+      const utf8FileContent = bom + fileContent;
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename=${goRulesJSONFilename.replace(/\.json$/, '.csv')}`);
-      res.status(HttpStatus.OK).send(fileContent);
+      res.status(HttpStatus.OK).send(utf8FileContent);
     } catch (error) {
       throw new HttpException('Error generating CSV for rule run', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -155,9 +158,12 @@ export class ScenarioDataController {
     try {
       const scenarios = await this.scenarioDataService.processProvidedScenarios(goRulesJSONFilename, file);
       const csvContent = await this.scenarioDataService.getCSVForRuleRun(goRulesJSONFilename, ruleContent, scenarios);
-      res.setHeader('Content-Type', 'text/csv');
+      // UTF- 8 encoding with BOM
+      const bom = '\uFEFF';
+      const utf8FileContent = bom + csvContent;
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename=processed_data.csv`);
-      res.status(HttpStatus.OK).send(csvContent);
+      res.status(HttpStatus.OK).send(utf8FileContent);
     } catch (error) {
       throw new HttpException('Error processing CSV file', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -178,9 +184,12 @@ export class ScenarioDataController {
         simulationContext,
         testScenarioCount,
       );
-      res.setHeader('Content-Type', 'text/csv');
+      // UTF- 8 encoding with BOM
+      const bom = '\uFEFF';
+      const utf8FileContent = bom + fileContent;
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename=${goRulesJSONFilename.replace(/\.json$/, '.csv')}`);
-      res.status(HttpStatus.OK).send(fileContent);
+      res.status(HttpStatus.OK).send(utf8FileContent);
     } catch (error) {
       throw new HttpException('Error generating CSV for rule run', HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -19,6 +19,7 @@ import { ScenarioData } from './scenarioData.schema';
 import { RuleContent } from '../ruleMapping/ruleMapping.interface';
 import { CreateScenarioDto } from './dto/create-scenario.dto';
 import { FileNotFoundError } from '../../utils/readFile';
+import { RuleRunResults } from './scenarioData.interface';
 
 @Controller('api/scenario')
 export class ScenarioDataController {
@@ -173,7 +174,7 @@ export class ScenarioDataController {
   async getCSVTests(
     @Body('goRulesJSONFilename') goRulesJSONFilename: string,
     @Body('ruleContent') ruleContent: RuleContent,
-    @Body('simulationContext') simulationContext: unknown,
+    @Body('simulationContext') simulationContext: RuleRunResults,
     @Body('testScenarioCount') testScenarioCount: number,
     @Res() res: Response,
   ) {

--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -183,7 +183,7 @@ export class ScenarioDataController {
         goRulesJSONFilename,
         ruleContent,
         simulationContext,
-        testScenarioCount,
+        testScenarioCount && testScenarioCount > 0 ? testScenarioCount : undefined,
       );
       // UTF- 8 encoding with BOM
       const bom = '\uFEFF';

--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -113,6 +113,15 @@ export class ScenarioDataController {
     }
   }
 
+  sendCSV = (res: Response, fileContent: string, filepath: string = 'processed_data.csv') => {
+    // UTF- 8 encoding with BOM
+    const bom = '\uFEFF';
+    const utf8CsvContent = bom + fileContent;
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename=${filepath.replace(/\.json$/, '.csv')}`);
+    res.status(HttpStatus.OK).send(utf8CsvContent);
+  };
+
   @Post('/evaluation')
   async getCSVForRuleRun(
     @Body('filepath') filepath: string,
@@ -121,12 +130,7 @@ export class ScenarioDataController {
   ) {
     try {
       const fileContent = await this.scenarioDataService.getCSVForRuleRun(filepath, ruleContent);
-      // UTF- 8 encoding with BOM
-      const bom = '\uFEFF';
-      const utf8FileContent = bom + fileContent;
-      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-      res.setHeader('Content-Disposition', `attachment; filename=${filepath.replace(/\.json$/, '.csv')}`);
-      res.status(HttpStatus.OK).send(utf8FileContent);
+      this.sendCSV(res, fileContent, filepath);
     } catch (error) {
       throw new HttpException('Error generating CSV for rule run', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -159,12 +163,7 @@ export class ScenarioDataController {
     try {
       const scenarios = await this.scenarioDataService.processProvidedScenarios(filepath, file);
       const csvContent = await this.scenarioDataService.getCSVForRuleRun(filepath, ruleContent, scenarios);
-      // UTF- 8 encoding with BOM
-      const bom = '\uFEFF';
-      const utf8FileContent = bom + csvContent;
-      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-      res.setHeader('Content-Disposition', `attachment; filename=processed_data.csv`);
-      res.status(HttpStatus.OK).send(utf8FileContent);
+      this.sendCSV(res, csvContent);
     } catch (error) {
       throw new HttpException('Error processing CSV file', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -185,12 +184,7 @@ export class ScenarioDataController {
         simulationContext,
         testScenarioCount && testScenarioCount > 0 ? testScenarioCount : undefined,
       );
-      // UTF- 8 encoding with BOM
-      const bom = '\uFEFF';
-      const utf8FileContent = bom + fileContent;
-      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-      res.setHeader('Content-Disposition', `attachment; filename=${filepath.replace(/\.json$/, '.csv')}`);
-      res.status(HttpStatus.OK).send(utf8FileContent);
+      this.sendCSV(res, fileContent, filepath);
     } catch (error) {
       throw new HttpException('Error generating CSV for rule run', HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -162,4 +162,27 @@ export class ScenarioDataController {
       throw new HttpException('Error processing CSV file', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
+
+  @Post('/test')
+  async getCSVTests(
+    @Body('goRulesJSONFilename') goRulesJSONFilename: string,
+    @Body('ruleContent') ruleContent: RuleContent,
+    @Body('simulationContext') simulationContext: unknown,
+    @Body('testScenarioCount') testScenarioCount: number,
+    @Res() res: Response,
+  ) {
+    try {
+      const fileContent = await this.scenarioDataService.generateTestCSVScenarios(
+        goRulesJSONFilename,
+        ruleContent,
+        simulationContext,
+        testScenarioCount,
+      );
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', `attachment; filename=${goRulesJSONFilename.replace(/\.json$/, '.csv')}`);
+      res.status(HttpStatus.OK).send(fileContent);
+    } catch (error) {
+      throw new HttpException('Error generating CSV for rule run', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
 }

--- a/src/api/scenarioData/scenarioData.service.ts
+++ b/src/api/scenarioData/scenarioData.service.ts
@@ -70,7 +70,7 @@ export class ScenarioDataService {
       throw new Error(`Failed to update scenario data: ${error.message}`);
     }
   }
-  ƒ;
+
   async deleteScenarioData(scenarioId: string): Promise<void> {
     try {
       const objectId = new Types.ObjectId(scenarioId);
@@ -459,7 +459,7 @@ export class ScenarioDataService {
       testScenarioCount || 100,
     );
 
-    const formattedExpectedResultsObject = reduceToCleanObj(ruleSchema.resultOutputs, 'name', 'value');
+    const formattedExpectedResultsObject = reduceToCleanObj(ruleSchema.resultOutputs, 'field', 'value');
     let nameCounter = 1;
     for (const scenario of combinations as ScenarioDataDocument[]) {
       const formattedVariablesObject = scenario;

--- a/src/api/scenarioData/scenarioData.service.ts
+++ b/src/api/scenarioData/scenarioData.service.ts
@@ -9,7 +9,7 @@ import { DocumentsService } from '../documents/documents.service';
 import { RuleSchema, RuleRunResults } from './scenarioData.interface';
 import { isEqual, reduceToCleanObj, extractUniqueKeys } from '../../utils/helpers';
 import { mapTraces } from '../../utils/handleTrace';
-import { parseCSV, extractKeys, formatVariables } from '../../utils/csv';
+import { parseCSV, extractKeys, formatVariables, cartesianProduct, complexCartesianProduct } from '../../utils/csv';
 
 @Injectable()
 export class ScenarioDataService {
@@ -245,5 +245,286 @@ export class ScenarioDataService {
     });
 
     return scenarios;
+  }
+
+  async generateCSVScenarios(
+    goRulesJSONFilename: string,
+    ruleContent: RuleContent,
+    newScenarios?: ScenarioData[],
+  ): Promise<string> {
+    const ruleRunResults: RuleRunResults = await this.runDecisionsForScenarios(
+      goRulesJSONFilename,
+      ruleContent,
+      newScenarios,
+    );
+
+    const keys = {
+      inputs: extractUniqueKeys(ruleRunResults, 'inputs'),
+      expectedResults: extractUniqueKeys(ruleRunResults, 'expectedResults'),
+      result: extractUniqueKeys(ruleRunResults, 'result'),
+    };
+
+    const headers = [
+      'Scenario',
+      'Results Match Expected (Pass/Fail)',
+      ...this.prefixKeys(keys.inputs, 'Input'),
+      ...this.prefixKeys(keys.expectedResults, 'Expected Result'),
+      ...this.prefixKeys(keys.result, 'Result'),
+    ];
+
+    const rows = Object.entries(ruleRunResults).map(([scenarioName, data]) => [
+      this.escapeCSVField(scenarioName),
+      data.resultMatch ? 'Pass' : 'Fail',
+      ...this.mapFields(data.inputs, keys.inputs),
+      ...this.mapFields(data.expectedResults, keys.expectedResults),
+      ...this.mapFields(data.result, keys.result),
+    ]);
+
+    return [headers, ...rows].map((row) => row.join(',')).join('\n');
+  }
+
+  private generatePossibleValues(input: any, defaultValue?: any): any[] {
+    const { type, dataType, validationCriteria, validationType, childFields } = input;
+
+    if (defaultValue !== null && defaultValue !== undefined) return [defaultValue];
+
+    switch (type || dataType) {
+      case 'object-array':
+        const childCombinations = this.generateCombinations({ inputs: childFields });
+        return [childCombinations];
+
+      case 'number-input':
+        const numberValues = validationCriteria?.split(',').map((val: string) => val.trim());
+        const minValue = (numberValues && parseInt(numberValues[0], 10)) || 0;
+
+        const maxValue =
+          numberValues && numberValues[numberValues?.length - 1] !== minValue.toString()
+            ? numberValues[numberValues?.length - 1]
+            : 20;
+
+        const generateRandomNumbers = (count: number) =>
+          Array.from({ length: count }, () => Math.floor(Math.random() * (maxValue - minValue + 1)) + minValue);
+
+        switch (validationType) {
+          case '>=':
+            return generateRandomNumbers(5);
+          case '<=':
+            return generateRandomNumbers(5);
+          case '>':
+            return generateRandomNumbers(5).filter((val) => val > minValue);
+          case '<':
+            return generateRandomNumbers(5).filter((val) => val < maxValue);
+          // range exclusive
+          case '(num)':
+            return generateRandomNumbers(5).filter((val) => val > minValue && val < maxValue);
+          // range inclusive
+          case '[num]':
+            return generateRandomNumbers(5);
+          default:
+            return generateRandomNumbers(5);
+        }
+
+      case 'date':
+        const dateValues = validationCriteria?.split(',').map((val: string) => new Date(val.trim()).getTime());
+        const minDate = (dateValues && dateValues[0]) || new Date().getTime();
+        const maxDate =
+          dateValues && dateValues[dateValues?.length - 1] !== minDate
+            ? dateValues[dateValues?.length - 1]
+            : new Date().setFullYear(new Date().getFullYear() + 1);
+        const generateRandomDates = (count: number) =>
+          Array.from({ length: count }, () =>
+            new Date(minDate + Math.random() * (maxDate - minDate)).toISOString().slice(0, 10),
+          );
+        switch (validationType) {
+          case '>=':
+            return generateRandomDates(5);
+          case '<=':
+            return generateRandomDates(5);
+          case '>':
+            return generateRandomDates(5).filter((date) => new Date(date).getTime() > minDate);
+          case '<':
+            return generateRandomDates(5).filter((date) => new Date(date).getTime() < maxDate);
+          // range exclusive
+          case '(date)':
+            return generateRandomDates(5).filter(
+              (date) => new Date(date).getTime() > minDate && new Date(date).getTime() < maxDate,
+            );
+          // range inclusive
+          case '[date]':
+            return generateRandomDates(5);
+          default:
+            return generateRandomDates(5);
+        }
+
+      case 'text-input':
+        return validationCriteria.split(',').map((val: string) => val.trim());
+
+      case 'true-false':
+        return [true, false];
+
+      default:
+        return [];
+    }
+  }
+
+  private generateCombinations(data: any, simulationContext?, testScenarioCount?) {
+    const generateFieldPath = (field: string, parentPath: string = ''): string => {
+      return parentPath ? `${parentPath}.${field}` : field;
+    };
+
+    const mapInputs = (inputs: any[], parentPath: string = ''): { fields: string[]; values: any[][] } => {
+      return inputs.reduce(
+        (acc, input) => {
+          const currentPath = generateFieldPath(input.field, parentPath);
+          if (input.type === 'object-array') {
+            return {
+              fields: [...acc.fields, currentPath],
+              values: [...acc.values, this.generatePossibleValues(input)],
+            };
+          } else if (input.childFields && input.childFields.length > 0) {
+            const childResult = mapInputs(input.childFields, currentPath);
+            return {
+              fields: [...acc.fields, ...childResult.fields],
+              values: [...acc.values, ...childResult.values],
+            };
+          } else {
+            const defaultValue = simulationContext?.[input.field];
+            const possibleValues = this.generatePossibleValues(input, defaultValue);
+            return {
+              fields: [...acc.fields, currentPath],
+              values: [...acc.values, possibleValues],
+            };
+          }
+        },
+        { fields: [], values: [] },
+      );
+    };
+
+    const { fields, values } = mapInputs(data.inputs);
+
+    const possibleCombinationLength = values.reduce((acc, val) => acc * val.length, 1);
+    const inputCombinations =
+      possibleCombinationLength > 1000 ? complexCartesianProduct(values, testScenarioCount) : cartesianProduct(values);
+
+    // Map combinations back to fields
+    const resultObjects = this.generateObjectsFromCombinations(fields, inputCombinations);
+    return resultObjects;
+  }
+
+  private generateObjectsFromCombinations(fields: string[], combinations: any[][]) {
+    return combinations.map((combination) => {
+      const obj: { [key: string]: any } = {};
+      fields.forEach((field, index) => {
+        const fieldParts = field.split('.');
+        let currentObj = obj;
+        for (let i = 0; i < fieldParts.length - 1; i++) {
+          if (!currentObj[fieldParts[i]]) {
+            currentObj[fieldParts[i]] = Array.isArray(combination[index]) ? [] : {};
+          }
+          currentObj = currentObj[fieldParts[i]];
+        }
+        const lastPart = fieldParts[fieldParts.length - 1];
+        if (Array.isArray(combination[index])) {
+          currentObj[lastPart] = combination[index];
+        } else {
+          currentObj[lastPart] = combination[index];
+        }
+      });
+      return obj;
+    });
+  }
+
+  async generateTestScenarios(
+    goRulesJSONFilename: string,
+    ruleContent?: RuleContent,
+    simulationContext?,
+    testScenarioCount?: number,
+  ): Promise<{ [scenarioId: string]: any }> {
+    if (!ruleContent) {
+      const fileContent = await this.documentsService.getFileContent(goRulesJSONFilename);
+      ruleContent = await JSON.parse(fileContent.toString());
+    }
+    const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleContent);
+    const results: { [scenarioId: string]: any } = {};
+
+    const combinations = this.generateCombinations(ruleSchema, simulationContext, testScenarioCount).slice(
+      0,
+      testScenarioCount || 100,
+    );
+
+    const formattedExpectedResultsObject = reduceToCleanObj(ruleSchema.resultOutputs, 'name', 'value');
+    let nameCounter = 1;
+    for (const scenario of combinations as ScenarioDataDocument[]) {
+      const formattedVariablesObject = scenario;
+      const title = `testCase${nameCounter++}`;
+
+      try {
+        const decisionResult = await this.decisionsService.runDecision(
+          ruleContent,
+          goRulesJSONFilename,
+          formattedVariablesObject,
+          {
+            trace: true,
+          },
+        );
+
+        const resultMatches =
+          Object.keys(formattedExpectedResultsObject).length > 0
+            ? isEqual(decisionResult.result, formattedExpectedResultsObject)
+            : true;
+
+        const scenarioResult = {
+          inputs: mapTraces(decisionResult.trace, ruleSchema, 'input'),
+          outputs: mapTraces(decisionResult.trace, ruleSchema, 'output'),
+          expectedResults: formattedExpectedResultsObject || {},
+          result: decisionResult.result || {},
+          resultMatch: resultMatches,
+        };
+
+        results[title] = scenarioResult;
+      } catch (error) {
+        console.error(`Error running decision for scenario ${title}: ${error.message}`);
+        results[title] = { error: error.message };
+      }
+    }
+    return results;
+  }
+
+  async generateTestCSVScenarios(
+    goRulesJSONFilename: string,
+    ruleContent: RuleContent,
+    simulationContext: RuleRunResults,
+    testScenarioCount?: number,
+  ) {
+    const ruleRunResults: RuleRunResults = await this.generateTestScenarios(
+      goRulesJSONFilename,
+      ruleContent,
+      simulationContext,
+      testScenarioCount,
+    );
+
+    const keys = {
+      inputs: extractUniqueKeys(ruleRunResults, 'inputs'),
+      expectedResults: extractUniqueKeys(ruleRunResults, 'expectedResults'),
+      result: extractUniqueKeys(ruleRunResults, 'result'),
+    };
+
+    const headers = [
+      'Scenario',
+      'Results Match Expected (Pass/Fail)',
+      ...this.prefixKeys(keys.inputs, 'Input'),
+      ...this.prefixKeys(keys.expectedResults, 'Expected Result'),
+      ...this.prefixKeys(keys.result, 'Result'),
+    ];
+
+    const rows = Object.entries(ruleRunResults).map(([scenarioName, data]) => [
+      this.escapeCSVField(scenarioName),
+      `n/a`,
+      ...this.mapFields(data.inputs, keys.inputs),
+      ...this.mapFields(data.expectedResults, keys.expectedResults),
+      ...this.mapFields(data.result, keys.result),
+    ]);
+
+    return [headers, ...rows].map((row) => row.join(',')).join('\n');
   }
 }

--- a/src/utils/csv.spec.ts
+++ b/src/utils/csv.spec.ts
@@ -1,0 +1,87 @@
+import { complexCartesianProduct, generateCombinationsWithLimit } from './csv';
+
+describe('CSV Utility Functions', () => {
+  describe('complexCartesianProduct', () => {
+    it('should generate correct combinations for simple input', () => {
+      const input = [
+        [1, 2],
+        ['a', 'b'],
+      ];
+      const result = complexCartesianProduct(input);
+      expect(result).toEqual([
+        [1, 'a'],
+        [1, 'b'],
+        [2, 'a'],
+        [2, 'b'],
+      ]);
+    });
+
+    it('should respect the limit parameter', () => {
+      const input = [
+        [1, 2, 3],
+        ['a', 'b', 'c'],
+        [true, false],
+      ];
+      const result = complexCartesianProduct(input, 5);
+      expect(result.length).toBe(5);
+    });
+
+    it('should handle empty input arrays', () => {
+      const input: any[][] = [];
+      const result = complexCartesianProduct(input);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle input with empty sub-arrays', () => {
+      const input = [[1, 2], ['a', 'b'], []];
+      const result = complexCartesianProduct(input);
+      expect(result).toEqual([
+        [1, 'a'],
+        [1, 'b'],
+        [2, 'a'],
+        [2, 'b'],
+      ]);
+    });
+
+    it('should handle large input without exceeding memory limits', () => {
+      const largeInput = Array(10).fill([1, 2, 3, 4, 5]);
+      const result = complexCartesianProduct(largeInput, 1000000);
+      expect(result.length).toBe(1000000);
+    });
+  });
+
+  describe('generateCombinationsWithLimit', () => {
+    it('should generate all combinations for a small input', () => {
+      const input = ['a', 'b', 'c'];
+      const result = generateCombinationsWithLimit(input);
+      const expectedResult = [['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'c'], ['b'], ['b', 'c'], ['c']];
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should respect the limit parameter', () => {
+      const input = ['a', 'b', 'c', 'd', 'e'];
+      const result = generateCombinationsWithLimit(input, 10);
+      expect(result.length).toBe(10);
+    });
+
+    it('should handle empty input array', () => {
+      const input: string[] = [];
+      const result = generateCombinationsWithLimit(input);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle single element input array', () => {
+      const input = ['a'];
+      const result = generateCombinationsWithLimit(input);
+      expect(result).toEqual([['a']]);
+    });
+
+    it('should handle large input without exceeding memory limits', () => {
+      const largeInput = Array(20)
+        .fill(0)
+        .map((_, i) => String.fromCharCode(97 + i));
+      const result = generateCombinationsWithLimit(largeInput, 1000000);
+      expect(result.length).toBe(1000000);
+    });
+  });
+});

--- a/src/utils/csv.spec.ts
+++ b/src/utils/csv.spec.ts
@@ -7,7 +7,7 @@ describe('CSV Utility Functions', () => {
         [1, 2],
         ['a', 'b'],
       ];
-      const result = complexCartesianProduct(input);
+      const result = complexCartesianProduct<number | string>(input);
       expect(result).toEqual([
         [1, 'a'],
         [1, 'b'],
@@ -22,7 +22,7 @@ describe('CSV Utility Functions', () => {
         ['a', 'b', 'c'],
         [true, false],
       ];
-      const result = complexCartesianProduct(input, 5);
+      const result = complexCartesianProduct<number | string | boolean>(input, 5);
       expect(result.length).toBe(5);
     });
 
@@ -34,7 +34,7 @@ describe('CSV Utility Functions', () => {
 
     it('should handle input with empty sub-arrays', () => {
       const input = [[1, 2], ['a', 'b'], []];
-      const result = complexCartesianProduct(input);
+      const result = complexCartesianProduct<number | string>(input);
       expect(result).toEqual([
         [1, 'a'],
         [1, 'b'],
@@ -45,7 +45,7 @@ describe('CSV Utility Functions', () => {
 
     it('should handle large input without exceeding memory limits', () => {
       const largeInput = Array(10).fill([1, 2, 3, 4, 5]);
-      const result = complexCartesianProduct(largeInput, 1000000);
+      const result = complexCartesianProduct<number>(largeInput, 1000000);
       expect(result.length).toBe(1000000);
     });
   });

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -147,5 +147,5 @@ export const generateCombinationsWithLimit = (arr: string[], limit: number = 100
   };
 
   combine([], arr, 0);
-  return result;
+  return result.slice(0, limit);
 };

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -49,7 +49,10 @@ export const formatVariables = (row: string[], keys: string[], startIndex: numbe
     }
 
     const parts = key.match(/^([^\[]+)(?:\[(\d+)\])?(.*)$/);
-    if (parts) {
+    if (typeof value === 'string' && value.startsWith('[') && value.endsWith(']')) {
+      const valueToArray = value.slice(1, value.length - 1).split(', ');
+      result[key] = valueToArray;
+    } else if (parts) {
       const [, baseKey, arrayIndex, remainingKey] = parts;
 
       const pluralizedKey = `${baseKey}${Number(arrayIndex) > 0 ? 's' : ''}`;
@@ -122,5 +125,27 @@ export const complexCartesianProduct = (arrays: any[][], limit: number = 1000): 
     if (currentDimension < 0) break;
   }
 
+  return result;
+};
+
+/**
+ * Generates all combinations of a given array with varying lengths.
+ * @param arr The input array to generate combinations from.
+ * @param limit The maximum number of combinations to generate.
+ * @returns The generated product.
+ */
+export const generateCombinationsWithLimit = (arr: string[], limit: number = 1000): string[][] => {
+  const result: string[][] = [];
+
+  const combine = (prefix: string[], remaining: string[], start: number) => {
+    if (result.length >= limit) return; // Stop when the limit is reached
+    for (let i = start; i < remaining.length; i++) {
+      const newPrefix = [...prefix, remaining[i]];
+      result.push(newPrefix);
+      combine(newPrefix, remaining, i + 1);
+    }
+  };
+
+  combine([], arr, 0);
   return result;
 };

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,5 +1,5 @@
 import * as csvParser from 'csv-parser';
-import { formatValue } from './helpers';
+import { formatValue, filterKeys } from './helpers';
 import { Variable } from '../api/scenarioData/scenarioData.schema';
 
 /**
@@ -41,8 +41,7 @@ export const extractKeys = (headers: string[], prefix: string): string[] => {
  */
 export const formatVariables = (row: string[], keys: string[], startIndex: number, filterEmpty = false): Variable[] => {
   const result: { [key: string]: any } = {};
-
-  keys.forEach((key, index) => {
+  filterKeys(keys).forEach((key, index) => {
     const value = row[startIndex + index] ? formatValue(row[startIndex + index]) : null;
     if (filterEmpty && (value === null || value === undefined || value === '')) {
       return;
@@ -55,26 +54,24 @@ export const formatVariables = (row: string[], keys: string[], startIndex: numbe
     } else if (parts) {
       const [, baseKey, arrayIndex, remainingKey] = parts;
 
-      const pluralizedKey = `${baseKey}${Number(arrayIndex) > 0 ? 's' : ''}`;
-
-      if (!result[pluralizedKey]) {
-        result[pluralizedKey] = arrayIndex ? [] : {};
+      if (!result[baseKey]) {
+        result[baseKey] = arrayIndex ? [] : {};
       }
 
       if (arrayIndex) {
         const idx = parseInt(arrayIndex, 10) - 1;
-        if (!result[pluralizedKey][idx]) {
-          result[pluralizedKey][idx] = {};
+        if (!result[baseKey][idx]) {
+          result[baseKey][idx] = {};
         }
         if (remainingKey) {
-          result[pluralizedKey][idx][remainingKey] = value;
+          result[baseKey][idx][remainingKey] = value;
         } else {
-          result[pluralizedKey][idx] = value;
+          result[baseKey][idx] = value;
         }
       } else if (remainingKey) {
-        result[pluralizedKey][remainingKey] = value;
+        result[baseKey][remainingKey] = value;
       } else {
-        result[pluralizedKey] = value;
+        result[baseKey] = value;
       }
     } else {
       result[key] = value;

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -84,3 +84,43 @@ export const formatVariables = (row: string[], keys: string[], startIndex: numbe
     type: Array.isArray(value) ? 'array' : typeof value,
   }));
 };
+
+/**
+ * Generates a cartesian product of arrays.
+ * @param arrays The arrays to generate the product from.
+ * @returns The generated product.
+ */
+export const cartesianProduct = (arrays: any[][]): any[][] => {
+  return arrays.reduce((a, b) => a.flatMap((d) => b.map((e) => [...d, e])), [[]]);
+};
+
+/**
+ * Generates a cartesian product of arrays in a more memory-efficient way, with the ability to adjust the maximum number of combinations.
+ * @param arrays The arrays to generate the product from.
+ * @param limit The maximum number of combinations to generate.
+ * @returns The generated product.
+ */
+export const complexCartesianProduct = (arrays: any[][], limit: number = 1000): any[][] => {
+  const result: any[][] = [];
+  const maxIndex = arrays.map((arr) => arr.length - 1);
+  const indices = new Array(arrays.length).fill(0);
+
+  while (indices[0] <= maxIndex[0] && result.length < limit) {
+    result.push(indices.map((index, i) => arrays[i][index]));
+
+    let currentDimension = indices.length - 1;
+    while (currentDimension >= 0) {
+      if (indices[currentDimension] < maxIndex[currentDimension]) {
+        indices[currentDimension]++;
+        break;
+      } else {
+        indices[currentDimension] = 0;
+        currentDimension--;
+      }
+    }
+
+    if (currentDimension < 0) break;
+  }
+
+  return result;
+};

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -90,7 +90,7 @@ export const formatVariables = (row: string[], keys: string[], startIndex: numbe
  * @param arrays The arrays to generate the product from.
  * @returns The generated product.
  */
-export const cartesianProduct = (arrays: any[][]): any[][] => {
+export const cartesianProduct = <T>(arrays: T[][]): T[][] => {
   return arrays.reduce((a, b) => a.flatMap((d) => b.map((e) => [...d, e])), [[]]);
 };
 
@@ -100,8 +100,8 @@ export const cartesianProduct = (arrays: any[][]): any[][] => {
  * @param limit The maximum number of combinations to generate.
  * @returns The generated product.
  */
-export const complexCartesianProduct = (arrays: any[][], limit: number = 3000): any[][] => {
-  const result: any[][] = [];
+export const complexCartesianProduct = <T>(arrays: T[][], limit: number = 3000): T[][] => {
+  const result: T[][] = [];
   const maxIndex = arrays.map((arr) => arr.length - 1);
   const indices = new Array(arrays.length).fill(0);
 

--- a/src/utils/handleTrace.ts
+++ b/src/utils/handleTrace.ts
@@ -35,12 +35,14 @@ export const mapTraceToResult = (trace: TraceObject, ruleSchema: RuleSchema, typ
       newArray.forEach((item, index) => {
         index++;
         const keyName = `${arrayName.toString()}[${index}]`;
-        if (Object.keys(item).length === 0) {
-          result[`${keyName}${key}`] = item;
-        } else {
-          Object.keys(item).forEach((key) => {
-            result[`${keyName}${key}`] = item[key];
-          });
+        if (typeof item == 'object') {
+          if (Object.keys(item).length === 0) {
+            result[`${keyName}${key}`] = item;
+          } else {
+            Object.keys(item).forEach((key) => {
+              result[`${keyName}${key}`] = item[key];
+            });
+          }
         }
       });
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -65,6 +65,17 @@ export const reduceToCleanObj = (
   }, {});
 };
 
+//Filter out keys that have square brackets with the same base part (parent objects)
+export const filterKeys = (keyArray: string[]) => {
+  return keyArray.filter((key) => {
+    const baseKey = key.split('[')[0];
+    if (!key.includes('[')) {
+      return !keyArray.some((otherKey) => otherKey.includes(baseKey + '['));
+    }
+    return true;
+  });
+};
+
 /**
  * Extracts unique keys from a specified property.
  * @param object The object to extract keys from.
@@ -72,7 +83,7 @@ export const reduceToCleanObj = (
  * @returns An array of unique keys.
  */
 export const extractUniqueKeys = (object: Record<string, any>, property: string): string[] => {
-  return Array.from(
+  const uniqueKeyArray = Array.from(
     new Set(
       Object.values(object).flatMap((each) => {
         if (each[property]) {
@@ -82,6 +93,7 @@ export const extractUniqueKeys = (object: Record<string, any>, property: string)
       }),
     ),
   );
+  return filterKeys(uniqueKeyArray);
 };
 
 /**


### PR DESCRIPTION
- [x] Add multiselect handling to klamm inputs.
- [x] Update CSV exports to UTF-8 to properly render text
- [x] Update CSV field formatting to handle multiselect option rendering.
- [x] Create a scenario generation function. This handles the generation of scenarios using the validation information from klamm. This takes in the klamm inputs and rule content, and returns a csv document of these tests with their outputs. 


Implementation of this functionality required the creation of sub functions to:
- Generate possible values for each field. This is currently set to manually generate 10 different options for fields that are number or date ranges. This should be enough for testing purposes, but this has been left as a hardcoded value due to potential memory issues in the deployment environment. If a user selects values on the frontend, these are passed directly to these options, and no additional options are generated. This allows users to define specific fields that should not change.
- Generate possible combinations of these fields. This uses the cartesian product formula to find all possible combinations of arrays. A limit has been introduced here as well to handle possible memory concerns.
- Possible combinations are then mapped to their respective fields. Additional randomness is introduced in this step to produce a wide variety of combinations instead of linearly creating them - as that was leading to some combinations being completely cut from the end result if the selection of requested items was not long enough. Duplicates are removed after generation.
- The final result runs all generated scenarios through the decision of the rulecontent presented, creating a csv file with all scenarios up to the limit requested by the end user. Currently this is capped at 1000 due to memory concerns.