### PR TITLE
Added functionality to sync rules from the db with Klamm 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Before running your application locally, you'll need some environment variables.
 
 - MONGODB_URL: The URL for connecting to the MongoDB instance you created in the previous step. Set it to something like mongodb://localhost/nest.
 - FRONTEND_URI: The URI for the frontend application. Set it to http://localhost:8080.
+- GITHUB_RULES_BRANCH: Specifies which branch Klamm is syncing with
+- GITHUB_TOKEN: Optional github token to mitigate issues with rate limiting
 - GITHUB_APP_CLIENT_ID
 - GITHUB_APP_CLIENT_SECRET
 - KLAMM_API_URL: The base URL of your Klamm API

--- a/src/api/klamm/klamm.controller.spec.ts
+++ b/src/api/klamm/klamm.controller.spec.ts
@@ -13,8 +13,8 @@ describe('KlammController', () => {
         {
           provide: KlammService,
           useValue: {
-            getBREFields: jest.fn(() => Promise.resolve('expected result')),
-            getBREFieldFromName: jest.fn((fieldName) => Promise.resolve(`result for ${fieldName}`)), // Mock implementation
+            getKlammBREFields: jest.fn(() => Promise.resolve('expected result')),
+            getKlammBREFieldFromName: jest.fn((fieldName) => Promise.resolve(`result for ${fieldName}`)), // Mock implementation
           },
         },
       ],
@@ -25,14 +25,14 @@ describe('KlammController', () => {
   });
 
   it('should call getBREFields and return expected result', async () => {
-    expect(await controller.getBREFields('test')).toBe('expected result');
-    expect(service.getBREFields).toHaveBeenCalledTimes(1);
+    expect(await controller.getKlammBREFields('test')).toBe('expected result');
+    expect(service.getKlammBREFields).toHaveBeenCalledTimes(1);
   });
 
-  it('should call getBREFieldFromName with fieldName and return expected result', async () => {
+  it('should call getKlammFieldFromName with fieldName and return expected result', async () => {
     const fieldName = 'testField';
-    expect(await controller.getBREFieldFromName(fieldName)).toBe(`result for ${fieldName}`);
-    expect(service.getBREFieldFromName).toHaveBeenCalledWith(fieldName);
-    expect(service.getBREFieldFromName).toHaveBeenCalledTimes(1);
+    expect(await controller.getKlammBREFieldFromName(fieldName)).toBe(`result for ${fieldName}`);
+    expect(service.getKlammBREFieldFromName).toHaveBeenCalledWith(fieldName);
+    expect(service.getKlammBREFieldFromName).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/klamm/klamm.controller.ts
+++ b/src/api/klamm/klamm.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, Param } from '@nestjs/common';
+import { KlammField } from './klamm';
 import { KlammService } from './klamm.service';
 
 @Controller('api/klamm')
@@ -6,12 +7,12 @@ export class KlammController {
   constructor(private readonly klammService: KlammService) {}
 
   @Get('/brefields')
-  async getBREFields(@Query('searchText') searchText: string) {
-    return await this.klammService.getBREFields(searchText);
+  async getKlammBREFields(@Query('searchText') searchText: string) {
+    return await this.klammService.getKlammBREFields(searchText);
   }
 
   @Get('/brefield/:fieldName')
-  async getBREFieldFromName(@Param('fieldName') fieldName: string) {
-    return await this.klammService.getBREFieldFromName(fieldName);
+  async getKlammBREFieldFromName(@Param('fieldName') fieldName: string): Promise<KlammField[]> {
+    return await this.klammService.getKlammBREFieldFromName(fieldName);
   }
 }

--- a/src/api/klamm/klamm.d.ts
+++ b/src/api/klamm/klamm.d.ts
@@ -1,0 +1,18 @@
+export interface KlammField {
+  id: number;
+  name: string;
+  label: string;
+  description: string;
+}
+
+export interface KlammRulePayload {
+  name: string;
+  label: string;
+  rule_inputs: KlammField[];
+  rule_outputs: KlammField[];
+  child_rules: KlammRulePayload[];
+}
+
+export interface KlammRule extends KlammRulePayload {
+  id: number;
+}

--- a/src/api/klamm/klamm.module.ts
+++ b/src/api/klamm/klamm.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { RuleDataModule } from '../ruleData/ruleData.module';
+import { RuleMappingModule } from '../ruleMapping/ruleMapping.module';
+import { KlammSyncMetadata, KlammSyncMetadataSchema } from './klammSyncMetadata.schema';
+import { DocumentsService } from '../documents/documents.service';
+import { KlammController } from './klamm.controller';
+import { KlammService } from './klamm.service';
+
+@Module({
+  imports: [
+    RuleDataModule,
+    RuleMappingModule,
+    MongooseModule.forFeature([{ name: KlammSyncMetadata.name, schema: KlammSyncMetadataSchema }]),
+  ],
+  controllers: [KlammController],
+  providers: [KlammService, DocumentsService],
+})
+export class KlammModule {}

--- a/src/api/klamm/klamm.service.spec.ts
+++ b/src/api/klamm/klamm.service.spec.ts
@@ -1,64 +1,379 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { KlammService } from './klamm.service';
-import axios from 'axios';
-import { HttpException } from '@nestjs/common';
-
-// Mock axios
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+import { Model } from 'mongoose';
+import { KlammService, GITHUB_RULES_REPO } from './klamm.service';
+import { RuleDataService } from '../ruleData/ruleData.service';
+import { RuleMappingService } from '../ruleMapping/ruleMapping.service';
+import { DocumentsService } from '../documents/documents.service';
+import { KlammSyncMetadataDocument } from './klammSyncMetadata.schema';
+import { RuleData } from '../ruleData/ruleData.schema';
+import { KlammRulePayload } from './klamm';
 
 describe('KlammService', () => {
   let service: KlammService;
+  let ruleDataService: RuleDataService;
+  let ruleMappingService: RuleMappingService;
+  let documentsService: DocumentsService;
+  let klammSyncMetadata: Model<KlammSyncMetadataDocument>;
 
   beforeEach(async () => {
-    // Set environment variables for testing
-    process.env.KLAMM_API_URL = 'https://test.api';
-    process.env.KLAMM_API_AUTH_TOKEN = 'test-token';
+    ruleDataService = {
+      getRuleDataByFilepath: jest.fn(),
+    } as unknown as RuleDataService;
+    ruleMappingService = {
+      inputOutputSchemaFile: jest.fn(),
+    } as unknown as RuleMappingService;
+    documentsService = {
+      getFileContent: jest.fn(),
+    } as unknown as DocumentsService;
+    klammSyncMetadata = {
+      findOneAndUpdate: jest.fn(),
+      findOne: jest.fn(),
+    } as unknown as Model<KlammSyncMetadataDocument>;
 
-    mockedAxios.create.mockReturnThis();
-
-    service = new KlammService();
+    service = new KlammService(ruleDataService, ruleMappingService, documentsService, klammSyncMetadata);
   });
 
-  it('should return data on successful API call', async () => {
-    const responseData = ['field1', 'field2', 'field3'];
-    mockedAxios.get.mockResolvedValue({ data: responseData });
-    const searchText = 'test';
-    await expect(service.getBREFields(searchText)).resolves.toEqual(responseData);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.KLAMM_API_URL}/api/brefields?search=${searchText}`);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('should throw HttpException on API call failure', async () => {
-    mockedAxios.get.mockRejectedValue(new Error('Error fetching from Klamm'));
+  it('should initialize module correctly', async () => {
+    jest.spyOn(service as any, '_getUpdatedFilesFromGithub').mockResolvedValue(['file1.js']);
+    jest.spyOn(service as any, '_syncRules').mockResolvedValue(undefined);
+    jest.spyOn(service as any, '_updateLastSyncTimestamp').mockResolvedValue(undefined);
 
-    await expect(service.getBREFields('test')).rejects.toThrow(HttpException);
-    await expect(service.getBREFields('test')).rejects.toThrow('Error fetching from Klamm');
+    await service.onModuleInit();
+
+    expect(service['_getUpdatedFilesFromGithub']).toHaveBeenCalled();
+    expect(service['_syncRules']).toHaveBeenCalledWith(['file1.js']);
+    expect(service['_updateLastSyncTimestamp']).toHaveBeenCalled();
   });
 
-  it('should return the first field data on successful API call', async () => {
-    const fieldName = 'testField';
-    const responseData = { data: [{ id: 1, name: fieldName }] };
-    mockedAxios.get.mockResolvedValue({ data: responseData });
+  it('should handle error in onModuleInit', async () => {
+    jest.spyOn(service as any, '_getUpdatedFilesFromGithub').mockRejectedValue(new Error('Error'));
 
-    await expect(service.getBREFieldFromName(fieldName)).resolves.toEqual(responseData.data[0]);
-    expect(mockedAxios.get).toHaveBeenCalledWith(`${process.env.KLAMM_API_URL}/api/brefields`, {
-      params: { name: fieldName },
+    await service.onModuleInit();
+
+    expect(service['_getUpdatedFilesFromGithub']).toHaveBeenCalled();
+  });
+
+  it('should sync rules correctly', async () => {
+    const updatedFiles = ['file1.js', 'file2.js'];
+    const mockRule = { name: 'rule1', filepath: 'file1.js' } as RuleData;
+    jest.spyOn(ruleDataService, 'getRuleDataByFilepath').mockResolvedValue(mockRule);
+    jest.spyOn(service as any, '_syncRuleWithKlamm').mockResolvedValue(undefined);
+
+    await service['_syncRules'](updatedFiles);
+
+    expect(ruleDataService.getRuleDataByFilepath).toHaveBeenCalledWith('file1.js');
+    expect(service['_syncRuleWithKlamm']).toHaveBeenCalledWith(mockRule);
+  });
+
+  it('should handle error in _syncRules', async () => {
+    const updatedFiles = ['file1.js'];
+    jest.spyOn(ruleDataService, 'getRuleDataByFilepath').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_syncRules'](updatedFiles)).rejects.toThrow('Failed to sync rule from file file1.js');
+  });
+
+  it('should handle empty updatedFiles array', async () => {
+    const updatedFiles: string[] = [];
+    jest.spyOn(service as any, '_syncRuleWithKlamm').mockResolvedValue(undefined);
+
+    await service['_syncRules'](updatedFiles);
+
+    expect(service['_syncRuleWithKlamm']).not.toHaveBeenCalled();
+  });
+
+  it('should get updated files from GitHub correctly', async () => {
+    const mockFiles = ['file1.js', 'file2.js'];
+    const mockCommits = [{ url: 'commit1' }, { url: 'commit2' }];
+    const mockCommitDetails = { files: [{ filename: 'rules/file1.js' }, { filename: 'rules/file2.js' }] };
+    jest.spyOn(service as any, '_getLastSyncTimestamp').mockResolvedValue(1234567890);
+    jest
+      .spyOn(service.axiosGithubInstance, 'get')
+      .mockResolvedValueOnce({ data: mockCommits })
+      .mockResolvedValueOnce({ data: mockCommitDetails })
+      .mockResolvedValueOnce({ data: mockCommitDetails });
+
+    const result = await service['_getUpdatedFilesFromGithub']();
+
+    expect(service['_getLastSyncTimestamp']).toHaveBeenCalled();
+    expect(service.axiosGithubInstance.get).toHaveBeenCalledWith(
+      `${GITHUB_RULES_REPO}/commits?since=${new Date(1234567890).toISOString().split('.')[0]}Z&sha=${process.env.GITHUB_RULES_BRANCH}`,
+    );
+    expect(result).toEqual(mockFiles);
+  });
+
+  it('should handle error in _getUpdatedFilesFromGithub', async () => {
+    jest.spyOn(service as any, '_getLastSyncTimestamp').mockResolvedValue(1234567890);
+    jest.spyOn(service.axiosGithubInstance, 'get').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getUpdatedFilesFromGithub']()).rejects.toThrow('Error fetching updated files from GitHub');
+  });
+
+  it('should sync rule with Klamm correctly', async () => {
+    const mockRule = { name: 'rule1', filepath: 'rule1.json', title: 'Rule 1' } as RuleData;
+    const mockInputsOutputs = { inputs: [], outputs: [] };
+    const mockChildRules = [];
+    jest.spyOn(service as any, '_getInputOutputFieldsData').mockResolvedValue(mockInputsOutputs);
+    jest.spyOn(service as any, '_getChildRules').mockResolvedValue(mockChildRules);
+    jest.spyOn(service as any, '_addOrUpdateRuleInKlamm').mockResolvedValue(undefined);
+
+    await service['_syncRuleWithKlamm'](mockRule);
+
+    expect(service['_getInputOutputFieldsData']).toHaveBeenCalledWith(mockRule);
+    expect(service['_getChildRules']).toHaveBeenCalledWith(mockRule);
+    expect(service['_addOrUpdateRuleInKlamm']).toHaveBeenCalledWith({
+      name: mockRule.name,
+      label: mockRule.title,
+      rule_inputs: mockInputsOutputs.inputs,
+      rule_outputs: mockInputsOutputs.outputs,
+      child_rules: mockChildRules,
     });
   });
 
-  it('should throw HttpException with BAD_REQUEST if no field exists', async () => {
-    const fieldName = 'nonexistentField';
-    mockedAxios.get.mockResolvedValue({ data: { data: [] } });
+  it('should handle error in _syncRuleWithKlamm', async () => {
+    const mockRule = { name: 'rule1', filepath: 'rule1.json', title: 'Rule 1' } as RuleData;
+    jest.spyOn(service as any, '_getInputOutputFieldsData').mockRejectedValue(new Error('Error'));
 
-    await expect(service.getBREFieldFromName(fieldName)).rejects.toThrow(HttpException);
-    await expect(service.getBREFieldFromName(fieldName)).rejects.toThrow('Field name does not exist');
+    await expect(service['_syncRuleWithKlamm'](mockRule)).rejects.toThrow('Error syncing rule1');
   });
 
-  it('should throw HttpException with INTERNAL_SERVER_ERROR on API call failure', async () => {
-    const fieldName = 'testField';
-    mockedAxios.get.mockRejectedValue(new Error('Error fetching from Klamm'));
+  it('should get input/output fields data correctly', async () => {
+    const mockRule = { name: 'rule1', filepath: 'file1.js' } as RuleData;
+    const mockInputsOutputs = { inputs: [], resultOutputs: [] };
+    jest.spyOn(ruleMappingService, 'inputOutputSchemaFile').mockResolvedValue(mockInputsOutputs);
+    jest.spyOn(service as any, '_getFieldsFromIds').mockResolvedValue([]);
 
-    await expect(service.getBREFieldFromName(fieldName)).rejects.toThrow(HttpException);
-    await expect(service.getBREFieldFromName(fieldName)).rejects.toThrow('Error fetching from Klamm');
+    const result = await service['_getInputOutputFieldsData'](mockRule);
+
+    expect(ruleMappingService.inputOutputSchemaFile).toHaveBeenCalledWith(mockRule.filepath);
+    expect(service['_getFieldsFromIds']).toHaveBeenCalledWith([]);
+    expect(result).toEqual({ inputs: [], outputs: [] });
+  });
+
+  it('should handle error in _getInputOutputFieldsData', async () => {
+    const mockRule = { name: 'rule1', filepath: 'file1.js' } as RuleData;
+    jest.spyOn(ruleMappingService, 'inputOutputSchemaFile').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getInputOutputFieldsData'](mockRule)).rejects.toThrow(
+      'Error getting input/output fields for rule rule1',
+    );
+  });
+
+  it('should get fields from IDs correctly', async () => {
+    const mockIds = [1, 2, 3];
+    jest.spyOn(service as any, '_fetchFieldById').mockResolvedValue({});
+
+    const result = await service['_getFieldsFromIds'](mockIds);
+
+    expect(service['_fetchFieldById']).toHaveBeenCalledTimes(mockIds.length);
+    expect(result).toEqual([{}, {}, {}]);
+  });
+
+  it('should handle error in _getFieldsFromIds', async () => {
+    const mockIds = [1, 2, 3];
+    jest.spyOn(service as any, '_fetchFieldById').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getFieldsFromIds'](mockIds)).rejects.toThrow('Error fetching fields by IDs: Error');
+  });
+
+  it('should fetch field by ID correctly', async () => {
+    const mockId = 1;
+    jest.spyOn(service.axiosKlammInstance, 'get').mockResolvedValue({ data: {} });
+
+    const result = await service['_fetchFieldById'](mockId);
+
+    expect(service.axiosKlammInstance.get).toHaveBeenCalledWith(`${process.env.KLAMM_API_URL}/api/brerules/${mockId}`);
+    expect(result).toEqual({});
+  });
+
+  it('should handle error in _fetchFieldById', async () => {
+    const mockId = 1;
+    jest.spyOn(service.axiosKlammInstance, 'get').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_fetchFieldById'](mockId)).rejects.toThrow('Error fetching field with ID 1: Error');
+  });
+
+  it('should get child rules correctly', async () => {
+    const mockRule = { name: 'rule1', filepath: 'file1.js' } as RuleData;
+    const mockFileContent = Buffer.from(
+      JSON.stringify({ nodes: [{ type: 'decisionNode', content: { key: 'key1' } }] }),
+    );
+    jest.spyOn(documentsService, 'getFileContent').mockResolvedValue(mockFileContent);
+    jest.spyOn(service as any, '_getKlammRuleFromName').mockResolvedValue({});
+
+    const result = await service['_getChildRules'](mockRule);
+
+    expect(documentsService.getFileContent).toHaveBeenCalledWith(mockRule.filepath);
+    expect(service['_getKlammRuleFromName']).toHaveBeenCalledWith('key1');
+    expect(result).toEqual([{}]);
+  });
+
+  it('should handle error in _getChildRules', async () => {
+    const mockRule = { name: 'rule1', filepath: 'file1.js' } as RuleData;
+    jest.spyOn(documentsService, 'getFileContent').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getChildRules'](mockRule)).rejects.toThrow('Error gettting child rules for rule1');
+  });
+
+  it('should add or update rule in Klamm correctly', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    jest.spyOn(service as any, '_getKlammRuleFromName').mockResolvedValue({ id: 1 });
+    jest.spyOn(service as any, '_updateRuleInKlamm').mockResolvedValue(undefined);
+
+    await service['_addOrUpdateRuleInKlamm'](mockRulePayload);
+
+    expect(service['_getKlammRuleFromName']).toHaveBeenCalledWith(mockRulePayload.name);
+    expect(service['_updateRuleInKlamm']).toHaveBeenCalledWith(1, mockRulePayload);
+  });
+
+  it('should handle error in _addOrUpdateRuleInKlamm', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    jest.spyOn(service as any, '_getKlammRuleFromName').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_addOrUpdateRuleInKlamm'](mockRulePayload)).rejects.toThrow('Error');
+  });
+
+  it('should get Klamm rule from name correctly', async () => {
+    const mockRuleName = 'rule1';
+    jest.spyOn(service.axiosKlammInstance, 'get').mockResolvedValue({ data: { data: [{}] } });
+
+    const result = await service['_getKlammRuleFromName'](mockRuleName);
+
+    expect(service.axiosKlammInstance.get).toHaveBeenCalledWith(`${process.env.KLAMM_API_URL}/api/brerules`, {
+      params: { name: mockRuleName },
+    });
+    expect(result).toEqual({});
+  });
+
+  it('should handle error in _getKlammRuleFromName', async () => {
+    const mockRuleName = 'rule1';
+    jest.spyOn(service.axiosKlammInstance, 'get').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getKlammRuleFromName'](mockRuleName)).rejects.toThrow('Error getting rule rule1 from Klamm');
+  });
+
+  it('should add rule in Klamm correctly', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    jest.spyOn(service.axiosKlammInstance, 'post').mockResolvedValue(undefined);
+
+    await service['_addRuleInKlamm'](mockRulePayload);
+
+    expect(service.axiosKlammInstance.post).toHaveBeenCalledWith(
+      `${process.env.KLAMM_API_URL}/api/brerules`,
+      mockRulePayload,
+    );
+  });
+
+  it('should handle error in _addRuleInKlamm', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    jest.spyOn(service.axiosKlammInstance, 'post').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_addRuleInKlamm'](mockRulePayload)).rejects.toThrow('Error adding rule to Klamm');
+  });
+
+  it('should update rule in Klamm correctly', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    const mockRuleId = 1;
+    jest.spyOn(service.axiosKlammInstance, 'put').mockResolvedValue(undefined);
+
+    await service['_updateRuleInKlamm'](mockRuleId, mockRulePayload);
+
+    expect(service.axiosKlammInstance.put).toHaveBeenCalledWith(
+      `${process.env.KLAMM_API_URL}/api/brerules/${mockRuleId}`,
+      mockRulePayload,
+    );
+  });
+
+  it('should handle error in _updateRuleInKlamm', async () => {
+    const mockRulePayload = { name: 'rule1' } as KlammRulePayload;
+    const mockRuleId = 1;
+    jest.spyOn(service.axiosKlammInstance, 'put').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_updateRuleInKlamm'](mockRuleId, mockRulePayload)).rejects.toThrow(
+      'Error updating rule 1 in Klamm',
+    );
+  });
+
+  it('should update last sync timestamp correctly', async () => {
+    jest.spyOn(klammSyncMetadata, 'findOneAndUpdate').mockResolvedValue(undefined);
+
+    await service['_updateLastSyncTimestamp']();
+
+    expect(klammSyncMetadata.findOneAndUpdate).toHaveBeenCalledWith(
+      { key: 'singleton' },
+      { lastSyncTimestamp: expect.any(Number) },
+      { upsert: true, new: true },
+    );
+  });
+
+  it('should handle error in _updateLastSyncTimestamp', async () => {
+    jest.spyOn(klammSyncMetadata, 'findOneAndUpdate').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_updateLastSyncTimestamp']()).rejects.toThrow('Failed to update last sync timestamp');
+  });
+
+  it('should get last sync timestamp correctly', async () => {
+    const mockTimestamp = 1234567890;
+    jest.spyOn(klammSyncMetadata, 'findOne').mockResolvedValue({ lastSyncTimestamp: mockTimestamp });
+
+    const result = await service['_getLastSyncTimestamp']();
+
+    expect(klammSyncMetadata.findOne).toHaveBeenCalledWith({ key: 'singleton' });
+    expect(result).toEqual(mockTimestamp);
+  });
+
+  it('should handle error in _getLastSyncTimestamp', async () => {
+    jest.spyOn(klammSyncMetadata, 'findOne').mockRejectedValue(new Error('Error'));
+
+    await expect(service['_getLastSyncTimestamp']()).rejects.toThrow('Failed to get last sync timestamp');
+  });
+
+  it('should get Klamm BRE fields correctly', async () => {
+    const searchText = 'test';
+    const mockData = ['field1', 'field2'];
+    jest.spyOn(service.axiosKlammInstance, 'get').mockResolvedValue({ data: mockData });
+
+    const result = await service.getKlammBREFields(searchText);
+
+    expect(service.axiosKlammInstance.get).toHaveBeenCalledWith(
+      `${process.env.KLAMM_API_URL}/api/brefields?search=${encodeURIComponent(searchText.trim())}`,
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it('should handle error in getKlammBREFields', async () => {
+    const searchText = 'test';
+    jest.spyOn(service.axiosKlammInstance, 'get').mockRejectedValue(new Error('Error'));
+
+    await expect(service.getKlammBREFields(searchText)).rejects.toThrow('Error fetching from Klamm');
+  });
+
+  it('should get Klamm BRE field from name correctly', async () => {
+    const fieldName = 'field1';
+    const mockData = [{ id: 1, name: 'field1' }];
+    jest.spyOn(service.axiosKlammInstance, 'get').mockResolvedValue({ data: { data: mockData } });
+
+    const result = await service.getKlammBREFieldFromName(fieldName);
+
+    expect(service.axiosKlammInstance.get).toHaveBeenCalledWith(`${process.env.KLAMM_API_URL}/api/brefields`, {
+      params: { name: encodeURIComponent(fieldName.trim()) },
+    });
+    expect(result).toEqual(mockData[0]);
+  });
+
+  it('should handle error in getKlammBREFieldFromName', async () => {
+    const fieldName = 'field1';
+    jest.spyOn(service.axiosKlammInstance, 'get').mockRejectedValue(new Error('Error'));
+
+    await expect(service.getKlammBREFieldFromName(fieldName)).rejects.toThrow('Error fetching from Klamm');
+  });
+
+  it('should throw InvalidFieldRequest error if field name does not exist', async () => {
+    const fieldName = 'field1';
+    jest.spyOn(service.axiosKlammInstance, 'get').mockResolvedValue({ data: { data: [] } });
+
+    await expect(service.getKlammBREFieldFromName(fieldName)).rejects.toThrow('Field name does not exist');
   });
 });

--- a/src/api/klamm/klamm.service.ts
+++ b/src/api/klamm/klamm.service.ts
@@ -10,7 +10,7 @@ import { RuleData } from '../ruleData/ruleData.schema';
 import { DocumentsService } from '../documents/documents.service';
 import { KlammSyncMetadata, KlammSyncMetadataDocument } from './klammSyncMetadata.schema';
 
-export const GITHUB_RULES_REPO = 'https://api.github.com/repos/bcgov/brms-rules';
+export const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO || 'https://api.github.com/repos/bcgov/brms-rules';
 
 export class InvalidFieldRequest extends Error {
   constructor(message: string) {
@@ -85,6 +85,7 @@ export class KlammService {
   }
 
   private async _syncRules(updatedFiles: string[]): Promise<void> {
+    const errors: string[] = [];
     for (const ruleFilepath of updatedFiles) {
       try {
         const rule = await this.ruleDataService.getRuleDataByFilepath(ruleFilepath);
@@ -96,8 +97,11 @@ export class KlammService {
         }
       } catch (error) {
         console.error(`Failed to sync rule from file ${ruleFilepath}:`, error.message);
-        throw new Error(`Failed to sync rule from file ${ruleFilepath}`);
+        errors.push(`Failed to sync rule from file ${ruleFilepath}: ${error.message}`);
       }
+    }
+    if (errors.length > 0) {
+      throw new Error(`Errors occurred during rule sync: ${errors.join('; ')}`);
     }
   }
 

--- a/src/api/klamm/klamm.service.ts
+++ b/src/api/klamm/klamm.service.ts
@@ -1,5 +1,16 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
 import axios, { AxiosInstance } from 'axios';
+import { KlammField, KlammRulePayload, KlammRule } from './klamm';
+import { deriveNameFromFilepath } from '../../utils/helpers';
+import { RuleDataService } from '../ruleData/ruleData.service';
+import { RuleMappingService } from '../ruleMapping/ruleMapping.service';
+import { RuleData } from '../ruleData/ruleData.schema';
+import { DocumentsService } from '../documents/documents.service';
+import { KlammSyncMetadata, KlammSyncMetadataDocument } from './klammSyncMetadata.schema';
+
+export const GITHUB_RULES_REPO = 'https://api.github.com/repos/bcgov/brms-rules';
 
 export class InvalidFieldRequest extends Error {
   constructor(message: string) {
@@ -11,14 +22,38 @@ export class InvalidFieldRequest extends Error {
 @Injectable()
 export class KlammService {
   axiosKlammInstance: AxiosInstance;
+  axiosGithubInstance: AxiosInstance;
 
-  constructor() {
+  constructor(
+    private readonly ruleDataService: RuleDataService,
+    private readonly ruleMappingService: RuleMappingService,
+    private readonly documentsService: DocumentsService,
+    @InjectModel(KlammSyncMetadata.name) private klammSyncMetadata: Model<KlammSyncMetadataDocument>,
+  ) {
     this.axiosKlammInstance = axios.create({
       headers: { Authorization: `Bearer ${process.env.KLAMM_API_AUTH_TOKEN}`, 'Content-Type': 'application/json' },
     });
+    const headers: Record<string, string> = {};
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    this.axiosGithubInstance = axios.create({ headers });
   }
 
-  async getBREFields(searchText: string): Promise<string[]> {
+  async onModuleInit() {
+    try {
+      console.info('Syncing existing rules with Klamm...');
+      const updatedFilesSinceLastDeploy = await this._getUpdatedFilesFromGithub();
+      console.info('Files updated since last deploy:', updatedFilesSinceLastDeploy);
+      await this._syncRules(updatedFilesSinceLastDeploy);
+      console.info('Completed syncing existing rules with Klamm');
+      await this._updateLastSyncTimestamp();
+    } catch (error) {
+      console.error('Unable to sync latest updates to Klamm:', error.message);
+    }
+  }
+
+  async getKlammBREFields(searchText: string): Promise<string[]> {
     try {
       const sanitizedSearchText = encodeURIComponent(searchText.trim());
       const { data } = await this.axiosKlammInstance.get(
@@ -30,7 +65,7 @@ export class KlammService {
     }
   }
 
-  async getBREFieldFromName(fieldName: string): Promise<any[]> {
+  async getKlammBREFieldFromName(fieldName: string): Promise<KlammField[]> {
     try {
       const sanitizedFieldName = encodeURIComponent(fieldName.trim());
       const { data } = await this.axiosKlammInstance.get(`${process.env.KLAMM_API_URL}/api/brefields`, {
@@ -46,6 +81,195 @@ export class KlammService {
         throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
       }
       throw new HttpException('Error fetching from Klamm', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private async _syncRules(updatedFiles: string[]): Promise<void> {
+    for (const ruleFilepath of updatedFiles) {
+      try {
+        const rule = await this.ruleDataService.getRuleDataByFilepath(ruleFilepath);
+        if (rule) {
+          await this._syncRuleWithKlamm(rule);
+          console.info(`Rule ${rule.name} synced`);
+        } else {
+          console.warn(`No rule found for changed file: ${ruleFilepath}`);
+        }
+      } catch (error) {
+        console.error(`Failed to sync rule from file ${ruleFilepath}:`, error.message);
+        throw new Error(`Failed to sync rule from file ${ruleFilepath}`);
+      }
+    }
+  }
+
+  async _getUpdatedFilesFromGithub(): Promise<string[]> {
+    try {
+      // Get last updated time from from db
+      const timestamp = await this._getLastSyncTimestamp();
+      const date = new Date(timestamp);
+      const formattedDate = date.toISOString().split('.')[0] + 'Z'; // Format required for github api
+      // Fetch commits since the specified timestamp
+      const commitsResponse = await this.axiosGithubInstance.get(
+        `${GITHUB_RULES_REPO}/commits?since=${formattedDate}&sha=${process.env.GITHUB_RULES_BRANCH}`,
+      );
+      const commits = commitsResponse.data;
+      // Fetch details for each commit to get the list of changed files
+      const updatedFiles = new Set<string>();
+      for (const commit of commits) {
+        const commitDetailsResponse = await this.axiosGithubInstance.get(commit.url);
+        const commitDetails = commitDetailsResponse.data;
+        if (commitDetails.files) {
+          for (const file of commitDetails.files) {
+            if (file.filename.startsWith('rules/')) {
+              updatedFiles.add(file.filename.replace(/^rules\//, ''));
+            }
+          }
+        }
+      }
+      return Array.from(updatedFiles);
+    } catch (error) {
+      console.error('Error fetching updated files from GitHub:', error);
+      throw new Error('Error fetching updated files from GitHub');
+    }
+  }
+
+  async _syncRuleWithKlamm(rule: RuleData) {
+    try {
+      // Get the inputs and outputs for the rule
+      const { inputs, outputs } = await this._getInputOutputFieldsData(rule);
+      // Get child rules of the rule
+      const childRules = await this._getChildRules(rule);
+      // Configure payload to add or update
+      const payloadToAddOrUpdate = {
+        name: rule.name,
+        label: rule.title,
+        rule_inputs: inputs,
+        rule_outputs: outputs,
+        child_rules: childRules,
+      };
+      // Add or update the rule in Klamm
+      await this._addOrUpdateRuleInKlamm(payloadToAddOrUpdate);
+    } catch (error) {
+      console.error(`Error syncing ${rule.name}`, error.message);
+      throw new Error(`Error syncing ${rule.name}`);
+    }
+  }
+
+  async _getInputOutputFieldsData(rule: RuleData): Promise<{ inputs: KlammField[]; outputs: KlammField[] }> {
+    try {
+      const { inputs, resultOutputs } = await this.ruleMappingService.inputOutputSchemaFile(rule.filepath);
+      const inputIds = inputs.map(({ id }) => Number(id));
+      const outputIds = resultOutputs.map(({ id }) => Number(id));
+      const inputResults = await this._getFieldsFromIds(inputIds);
+      const outputResults = await this._getFieldsFromIds(outputIds);
+      return { inputs: inputResults, outputs: outputResults };
+    } catch (error) {
+      console.error(`Error getting input/output fields for rule ${rule.name}`, error.message);
+      throw new Error(`Error getting input/output fields for rule ${rule.name}`);
+    }
+  }
+
+  async _getFieldsFromIds(ids: number[]): Promise<any[]> {
+    try {
+      const promises = ids.map((id) => this._fetchFieldById(id));
+      return await Promise.all(promises);
+    } catch (error) {
+      console.error(`Error fetching fields by IDs`, error.message);
+      throw new Error(`Error fetching fields by IDs: ${error.message}`);
+    }
+  }
+
+  private async _fetchFieldById(id: number): Promise<any> {
+    try {
+      const response = await this.axiosKlammInstance.get(`${process.env.KLAMM_API_URL}/api/brerules/${id}`);
+      return response.data;
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        console.warn(`Field with ID ${id} not found`);
+        return null;
+      } else {
+        console.error(`Error fetching field with ID ${id}`, error.message);
+        throw new Error(`Error fetching field with ID ${id}: ${error.message}`);
+      }
+    }
+  }
+
+  async _getChildRules(rule: RuleData) {
+    try {
+      const fileContent = await this.documentsService.getFileContent(rule.filepath);
+      const ruleContent = JSON.parse(fileContent.toString());
+      const childNodeNames: string[] = ruleContent.nodes
+        .filter(({ type, content }) => type === 'decisionNode' && content?.key)
+        .map(({ content: { key } }) => deriveNameFromFilepath(key));
+      const promises = childNodeNames.map((childNodeName) => this._getKlammRuleFromName(childNodeName));
+      const results = await Promise.all(promises);
+      return results.map((response) => response);
+    } catch (error) {
+      console.error(`Error gettting child rules for ${rule.name}:`, error.message);
+      throw new Error(`Error gettting child rules for ${rule.name}`);
+    }
+  }
+
+  async _addOrUpdateRuleInKlamm(rulePayload: KlammRulePayload) {
+    // Check if rule exists already and update it if it does, add it if it doesn't
+    const existingRule = await this._getKlammRuleFromName(rulePayload.name);
+    if (existingRule) {
+      this._updateRuleInKlamm(existingRule.id, rulePayload);
+    } else {
+      this._addRuleInKlamm(rulePayload);
+    }
+  }
+
+  async _getKlammRuleFromName(ruleName: string): Promise<KlammRule> {
+    try {
+      const { data } = await this.axiosKlammInstance.get(`${process.env.KLAMM_API_URL}/api/brerules`, {
+        params: { name: ruleName },
+      });
+      return data.data[0];
+    } catch (error) {
+      console.error(`Error getting rule ${ruleName} from Klamm:`, error.message);
+      throw new Error(`Error getting rule ${ruleName} from Klamm`);
+    }
+  }
+
+  async _addRuleInKlamm(rulePayload: KlammRulePayload) {
+    try {
+      await this.axiosKlammInstance.post(`${process.env.KLAMM_API_URL}/api/brerules`, rulePayload);
+    } catch (error) {
+      console.error('Error adding rule to Klamm:', error.message);
+      throw new Error('Error adding rule to Klamm');
+    }
+  }
+
+  async _updateRuleInKlamm(currentKlamRuleId: number, rulePayload: KlammRulePayload) {
+    try {
+      await this.axiosKlammInstance.put(`${process.env.KLAMM_API_URL}/api/brerules/${currentKlamRuleId}`, rulePayload);
+    } catch (error) {
+      console.error(`Error updating rule ${currentKlamRuleId} in Klamm:`, error.message);
+      throw new Error(`Error updating rule ${currentKlamRuleId} in Klamm`);
+    }
+  }
+
+  async _updateLastSyncTimestamp(): Promise<void> {
+    try {
+      const timestamp = Date.now();
+      await this.klammSyncMetadata.findOneAndUpdate(
+        { key: 'singleton' },
+        { lastSyncTimestamp: timestamp },
+        { upsert: true, new: true },
+      );
+    } catch (error) {
+      console.error('Failed to update last sync timestamp', error.message);
+      throw new Error('Failed to update last sync timestamp');
+    }
+  }
+
+  private async _getLastSyncTimestamp(): Promise<number> {
+    try {
+      const record = await this.klammSyncMetadata.findOne({ key: 'singleton' });
+      return record ? record.lastSyncTimestamp : 0;
+    } catch (error) {
+      console.error('Failed to get last sync timestamp:', error.message);
+      throw new Error('Failed to get last sync timestamp');
     }
   }
 }

--- a/src/api/klamm/klammSyncMetadata.schema.ts
+++ b/src/api/klamm/klammSyncMetadata.schema.ts
@@ -1,0 +1,15 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema()
+export class KlammSyncMetadata {
+  @Prop({ type: String, unique: true, default: 'singleton' }) // ensures only one copy of this document
+  key: string;
+
+  @Prop({ type: Number, description: 'Timestamp of when the rules were last synced to Klamm' })
+  lastSyncTimestamp: number;
+}
+
+export type KlammSyncMetadataDocument = KlammSyncMetadata & Document;
+
+export const KlammSyncMetadataSchema = SchemaFactory.createForClass(KlammSyncMetadata);

--- a/src/api/ruleData/ruleData.module.ts
+++ b/src/api/ruleData/ruleData.module.ts
@@ -15,5 +15,6 @@ import { DocumentsService } from '../documents/documents.service';
   ],
   controllers: [RuleDataController],
   providers: [RuleDataService, DocumentsService],
+  exports: [RuleDataService],
 })
 export class RuleDataModule {}

--- a/src/api/ruleData/ruleData.service.spec.ts
+++ b/src/api/ruleData/ruleData.service.spec.ts
@@ -79,6 +79,11 @@ describe('RuleDataService', () => {
     expect(await service.getRuleData(mockRuleData._id)).toEqual(mockRuleData);
   });
 
+  it('should get data for a rule by filepath', async () => {
+    MockRuleDataModel.findOne = jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(mockRuleData) });
+    expect(await service.getRuleDataByFilepath(mockRuleData.filepath)).toEqual(mockRuleData);
+  });
+
   it('should create rule data', async () => {
     expect(await service.createRuleData(mockRuleData)).toEqual(mockRuleData);
   });

--- a/src/api/ruleData/ruleData.service.ts
+++ b/src/api/ruleData/ruleData.service.ts
@@ -8,6 +8,8 @@ import { RuleData, RuleDataDocument } from './ruleData.schema';
 import { RuleDraft, RuleDraftDocument } from './ruleDraft.schema';
 import { deriveNameFromFilepath } from '../../utils/helpers';
 
+const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO || 'https://api.github.com/repos/bcgov/brms-rules';
+
 @Injectable()
 export class RuleDataService {
   constructor(
@@ -134,7 +136,7 @@ export class RuleDataService {
       if (process.env.GITHUB_TOKEN) {
         headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
       }
-      const branchesResponse = await axios.get('https://api.github.com/repos/bcgov/brms-rules/branches', { headers });
+      const branchesResponse = await axios.get(`${GITHUB_RULES_REPO}/branches`, { headers });
       const currentBranches = branchesResponse?.data.map(({ name }) => name);
       // Remove current reviewBranch if it no longer exists
       if (currentBranches) {

--- a/src/api/ruleMapping/ruleMapping.module.ts
+++ b/src/api/ruleMapping/ruleMapping.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RuleMappingController } from './ruleMapping.controller';
+import { RuleMappingService } from './ruleMapping.service';
+import { DocumentsService } from '../documents/documents.service';
+
+@Module({
+  controllers: [RuleMappingController],
+  providers: [RuleMappingService, DocumentsService],
+  exports: [RuleMappingService],
+})
+export class RuleMappingModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,17 +3,15 @@ import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { GithubAuthModule } from './auth/github-auth/github-auth.module';
 import { RuleDataModule } from './api/ruleData/ruleData.module';
+import { RuleMappingModule } from './api/ruleMapping/ruleMapping.module';
+import { KlammModule } from './api/klamm/klamm.module';
 import { DecisionsController } from './api/decisions/decisions.controller';
 import { DecisionsService } from './api/decisions/decisions.service';
 import { DocumentsController } from './api/documents/documents.controller';
 import { DocumentsService } from './api/documents/documents.service';
-import { RuleMappingController } from './api/ruleMapping/ruleMapping.controller';
-import { RuleMappingService } from './api/ruleMapping/ruleMapping.service';
 import { ScenarioData, ScenarioDataSchema } from './api/scenarioData/scenarioData.schema';
 import { ScenarioDataController } from './api/scenarioData/scenarioData.controller';
 import { ScenarioDataService } from './api/scenarioData/scenarioData.service';
-import { KlammController } from './api/klamm/klamm.controller';
-import { KlammService } from './api/klamm/klamm.service';
 
 @Module({
   imports: [
@@ -29,14 +27,10 @@ import { KlammService } from './api/klamm/klamm.service';
     MongooseModule.forFeature([{ name: ScenarioData.name, schema: ScenarioDataSchema }]),
     GithubAuthModule,
     RuleDataModule,
+    RuleMappingModule,
+    KlammModule,
   ],
-  controllers: [
-    DecisionsController,
-    DocumentsController,
-    RuleMappingController,
-    ScenarioDataController,
-    KlammController,
-  ],
-  providers: [DecisionsService, DocumentsService, RuleMappingService, ScenarioDataService, KlammService],
+  controllers: [DecisionsController, DocumentsController, ScenarioDataController],
+  providers: [DecisionsService, DocumentsService, ScenarioDataService],
 })
 export class AppModule {}


### PR DESCRIPTION
- [x]  Added functionality to sync rules from the db with Klamm
- [x]  Added functionality to check what rules have been updated in Github in order to know what to sync
- [x]  Moved ruleData, ruleMapping, and klamm apis into their own modules
- [x]  Added ability to get ruledata by filepath
- [x]  Added klammSyncMetadata for storing the last time data was synced to klamm
- [x]  Added Klamm types
- [x]  Renamed klamm controller/service functions

Accidentally created this pull request for "main" rather than dev.