### PR TITLE
Add validation error handling

### DIFF
--- a/src/api/decisions/decisions.controller.ts
+++ b/src/api/decisions/decisions.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Query, Body, HttpException, HttpStatus } from '@nestjs/common';
 import { DecisionsService } from './decisions.service';
 import { EvaluateDecisionDto, EvaluateDecisionWithContentDto } from './dto/evaluate-decision.dto';
+import { ValidationError } from './validations/validationError.service';
 
 @Controller('api/decisions')
 export class DecisionsController {
@@ -11,7 +12,11 @@ export class DecisionsController {
     try {
       return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace });
     } catch (error) {
-      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+      if (error instanceof ValidationError) {
+        throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+      } else {
+        throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
     }
   }
 

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
 import { DecisionsService } from './decisions.service';
+import { ValidationService } from './validations/validations.service';
 import { readFileSafely } from '../../utils/readFile';
 
 jest.mock('../../utils/readFile', () => ({
@@ -11,6 +12,7 @@ jest.mock('../../utils/readFile', () => ({
 
 describe('DecisionsService', () => {
   let service: DecisionsService;
+  let validationService: ValidationService;
   let mockEngine: Partial<ZenEngine>;
   let mockDecision: Partial<ZenDecision>;
 
@@ -23,11 +25,13 @@ describe('DecisionsService', () => {
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ConfigService, DecisionsService, { provide: ZenEngine, useValue: mockEngine }],
+      providers: [ConfigService, DecisionsService, ValidationService, { provide: ZenEngine, useValue: mockEngine }],
     }).compile();
 
     service = module.get<DecisionsService>(DecisionsService);
+    validationService = module.get<ValidationService>(ValidationService);
     service.engine = mockEngine as ZenEngine;
+    jest.spyOn(validationService, 'validateInputs').mockImplementation(() => {});
   });
 
   describe('runDecision', () => {

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -3,6 +3,8 @@ import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
 import { ConfigService } from '@nestjs/config';
 import { RuleContent } from '../ruleMapping/ruleMapping.interface';
 import { readFileSafely, FileNotFoundError } from '../../utils/readFile';
+import { ValidationService } from './validations/validations.service';
+import { ValidationError } from './validations/validationError.service';
 
 @Injectable()
 export class DecisionsService {
@@ -16,12 +18,19 @@ export class DecisionsService {
   }
 
   async runDecisionByContent(ruleContent: RuleContent, context: object, options: ZenEvaluateOptions) {
+    const validator = new ValidationService();
+    const ruleInputs = ruleContent?.nodes?.filter((node) => node.type === 'inputNode')[0]?.content;
     try {
+      validator.validateInputs(ruleInputs, context);
       const decision = this.engine.createDecision(ruleContent);
       return await decision.evaluate(context, options);
     } catch (error) {
-      console.error(error.message);
-      throw new Error(`Failed to run decision: ${error.message}`);
+      if (error instanceof ValidationError) {
+        throw new ValidationError(`Invalid input: ${error.message}`);
+      } else {
+        console.error(error.message);
+        throw new Error(`Failed to run decision: ${error.message}`);
+      }
     }
   }
 

--- a/src/api/decisions/validations/validationError.service.ts
+++ b/src/api/decisions/validations/validationError.service.ts
@@ -1,0 +1,19 @@
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+
+  getErrorCode(): string {
+    return 'VALIDATION_ERROR';
+  }
+
+  toJSON(): object {
+    return {
+      name: this.name,
+      message: this.message,
+      code: this.getErrorCode(),
+    };
+  }
+}

--- a/src/api/decisions/validations/validations.service.spec.ts
+++ b/src/api/decisions/validations/validations.service.spec.ts
@@ -1,0 +1,284 @@
+import { ValidationService } from './validations.service';
+import { ValidationError } from '../validations/validationError.service';
+
+describe('ValidationService', () => {
+  let validator: ValidationService;
+
+  beforeEach(() => {
+    validator = new ValidationService();
+  });
+
+  describe('validateInputs', () => {
+    it('should validate valid inputs', () => {
+      const ruleContent = {
+        fields: [
+          { field: 'age', type: 'number-input' },
+          { field: 'name', type: 'text-input' },
+        ],
+      };
+      const context = { age: 25, name: 'John Doe' };
+      expect(() => validator.validateInputs(ruleContent, context)).not.toThrow();
+    });
+  });
+
+  describe('validateField', () => {
+    it('should validate number input', () => {
+      const field = { field: 'age', type: 'number-input' };
+      const context = { age: 25 };
+      expect(() => validator['validateField'](field, context)).not.toThrow();
+    });
+
+    it('should validate date input', () => {
+      const field = { field: 'birthDate', type: 'date' };
+      const context = { birthDate: '2000-01-01' };
+      expect(() => validator['validateField'](field, context)).not.toThrow();
+    });
+
+    it('should validate text input', () => {
+      const field = { field: 'name', type: 'text-input' };
+      const context = { name: 'John Doe' };
+      expect(() => validator['validateField'](field, context)).not.toThrow();
+    });
+
+    it('should validate boolean input', () => {
+      const field = { field: 'isActive', type: 'true-false' };
+      const context = { isActive: true };
+      expect(() => validator['validateField'](field, context)).not.toThrow();
+    });
+
+    it('should throw ValidationError for invalid input type', () => {
+      const field = { field: 'age', type: 'number-input' };
+      const context = { age: 'twenty-five' };
+      expect(() => validator['validateField'](field, context)).toThrow(ValidationError);
+    });
+  });
+
+  describe('validateNumberCriteria', () => {
+    it('should validate equal to criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '==', validationCriteria: '25' };
+      expect(() => validator['validateNumberCriteria'](field, 25)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 26)).toThrow(ValidationError);
+    });
+
+    it('should validate not equal to criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '!=', validationCriteria: '25' };
+      expect(() => validator['validateNumberCriteria'](field, 26)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 25)).toThrow(ValidationError);
+    });
+
+    it('should validate greater than or equal to criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '>=', validationCriteria: '18' };
+      expect(() => validator['validateNumberCriteria'](field, 18)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 20)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 17)).toThrow(ValidationError);
+    });
+
+    it('should validate greater than criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '>', validationCriteria: '18' };
+      expect(() => validator['validateNumberCriteria'](field, 19)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 17)).toThrow(ValidationError);
+    });
+
+    it('should validate less than or equal to criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '<=', validationCriteria: '18' };
+      expect(() => validator['validateNumberCriteria'](field, 18)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 17)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 19)).toThrow(ValidationError);
+    });
+
+    it('should validate less than criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '<', validationCriteria: '18' };
+      expect(() => validator['validateNumberCriteria'](field, 17)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 18)).toThrow(ValidationError);
+    });
+
+    it('should validate between exclusive criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '(num)', validationCriteria: '[16, 20]' };
+      expect(() => validator['validateNumberCriteria'](field, 17)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 19)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 16)).toThrow(ValidationError);
+      expect(() => validator['validateNumberCriteria'](field, 20)).toThrow(ValidationError);
+      expect(() => validator['validateNumberCriteria'](field, 21)).toThrow(ValidationError);
+    });
+
+    it('should validate between inclusive criteria', () => {
+      const field = { field: 'age', type: 'number-input', validationType: '[num]', validationCriteria: '[16, 20]' };
+      expect(() => validator['validateNumberCriteria'](field, 16)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 17)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 19)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 20)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 15)).toThrow(ValidationError);
+      expect(() => validator['validateNumberCriteria'](field, 21)).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria', () => {
+      const field = {
+        field: 'age',
+        type: 'number-input',
+        validationType: '[=num]',
+        validationCriteria: '[18, 20]',
+      };
+      expect(() => validator['validateNumberCriteria'](field, 18)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 20)).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, 21)).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria with multiple values', () => {
+      const field = {
+        field: 'age',
+        type: 'number-input',
+        validationType: '[=nums]',
+        validationCriteria: '[18, 20]',
+      };
+      expect(() => validator['validateNumberCriteria'](field, [18])).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, [18, 20])).not.toThrow();
+      expect(() => validator['validateNumberCriteria'](field, [19, 20])).toThrow(ValidationError);
+    });
+  });
+
+  describe('validateDateCriteria', () => {
+    it('should validate equal to criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '==', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).toThrow(ValidationError);
+    });
+
+    it('should validate not equal to criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '!=', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).toThrow(ValidationError);
+    });
+
+    it('should validate greater than criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '>', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2022-12-31')).toThrow(ValidationError);
+    });
+
+    it('should validate greater than or equal to criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '>=', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2022-01-01')).toThrow(ValidationError);
+    });
+
+    it('should validate less than criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '<', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2022-12-31')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).toThrow(ValidationError);
+    });
+
+    it('should validate less than or equal to criteria', () => {
+      const field = { field: 'date', type: 'date', validationType: '<=', validationCriteria: '2023-01-01' };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).toThrow(ValidationError);
+    });
+
+    it('should validate between exclusive criteria', () => {
+      const field = {
+        field: 'date',
+        type: 'date',
+        validationType: '(date)',
+        validationCriteria: '[2023-01-01, 2024-01-03]',
+      };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2024-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-06-05')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2024-01-04')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2022-12-31')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).toThrow(ValidationError);
+    });
+
+    it('should validate between inclusive criteria', () => {
+      const field = {
+        field: 'date',
+        type: 'date',
+        validationType: '[date]',
+        validationCriteria: '[2023-01-01, 2023-01-03]',
+      };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-03')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-04')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2022-12-31')).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria with single dates', () => {
+      const field = {
+        field: 'date',
+        type: 'date',
+        validationType: '[=date]',
+        validationCriteria: '[2023-01-01, 2023-01-03]',
+      };
+      expect(() => validator['validateDateCriteria'](field, '2023-01-01')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-03')).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, '2023-01-02')).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, '2023-01-04')).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria with multiple dates', () => {
+      const field = {
+        field: 'date',
+        type: 'date',
+        validationType: '[=dates]',
+        validationCriteria: '[2023-01-01, 2023-01-03]',
+      };
+      expect(() => validator['validateDateCriteria'](field, ['2023-01-01'])).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, ['2023-01-01', '2023-01-03'])).not.toThrow();
+      expect(() => validator['validateDateCriteria'](field, ['2023-01-01', '2023-01-02'])).toThrow(ValidationError);
+      expect(() => validator['validateDateCriteria'](field, ['2023-01-01', '2023-01-04'])).toThrow(ValidationError);
+    });
+  });
+
+  describe('validateTextCriteria', () => {
+    it('should validate equal to criteria', () => {
+      const field = { field: 'status', type: 'text-input', validationType: '==', validationCriteria: 'active' };
+      expect(() => validator['validateTextCriteria'](field, 'active')).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, 'inactive')).toThrow(ValidationError);
+    });
+
+    it('should validate not equal to criteria', () => {
+      const field = { field: 'status', type: 'text-input', validationType: '!=', validationCriteria: 'active' };
+      expect(() => validator['validateTextCriteria'](field, 'inactive')).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, 'active')).toThrow(ValidationError);
+    });
+
+    it('should validate regex criteria', () => {
+      const field = {
+        field: 'email',
+        type: 'text-input',
+        validationType: 'regex',
+        validationCriteria: '^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$',
+      };
+      expect(() => validator['validateTextCriteria'](field, 'test@example.com')).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, 'invalid-email')).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria with single text', () => {
+      const field = {
+        field: 'status',
+        type: 'text-input',
+        validationType: '[=text]',
+        validationCriteria: 'active,testing',
+      };
+      expect(() => validator['validateTextCriteria'](field, 'active')).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, 'inactive')).toThrow(ValidationError);
+    });
+
+    it('should validate multiple criteria with multiple texts', () => {
+      const field = {
+        field: 'status',
+        type: 'text-input',
+        validationType: '[=texts]',
+        validationCriteria: 'active,inactive',
+      };
+      expect(() => validator['validateTextCriteria'](field, ['active'])).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, ['active', 'inactive'])).not.toThrow();
+      expect(() => validator['validateTextCriteria'](field, ['active', 'inactive', 'testing'])).toThrow(
+        ValidationError,
+      );
+    });
+  });
+});

--- a/src/api/decisions/validations/validations.service.ts
+++ b/src/api/decisions/validations/validations.service.ts
@@ -1,0 +1,311 @@
+import { Injectable } from '@nestjs/common';
+import { ValidationError } from '../validations/validationError.service';
+
+@Injectable()
+export class ValidationService {
+  validateInputs(ruleContent: any, context: Record<string, any>): void {
+    if (typeof ruleContent !== 'object' || !Array.isArray(ruleContent.fields)) {
+      return;
+    }
+
+    for (const field of ruleContent.fields) {
+      this.validateField(field, context);
+    }
+  }
+
+  private validateField(field: any, context: Record<string, any>): void {
+    if (!field.field || typeof field.field !== 'string') {
+      throw new ValidationError(`Invalid field definition: ${JSON.stringify(field)}`);
+    }
+
+    if (!(field.field in context)) {
+        return;
+    }
+
+    const input = context[field.field];
+
+    if (input === null || input === undefined) {
+      return;
+    }
+
+    this.validateType(field, input);
+    this.validateCriteria(field, input);
+
+    if (Array.isArray(field.childFields)) {
+      for (const childField of field.childFields) {
+        this.validateField(childField, input);
+      }
+    }
+  }
+
+  private validateType(field: any, input: any): void {
+    const { dataType, type, validationType } = field;
+    const actualType = typeof input;
+
+    switch (type || dataType) {
+      case 'number-input':
+        if (typeof input !== 'number' && validationType !== '[=nums]') {
+          throw new ValidationError(`Input ${field.field} should be a number, but got ${actualType}`);
+        } else if (validationType === '[=nums]' && !Array.isArray(input)) {
+          throw new ValidationError(`Input ${field.field} should be an array of numbers, but got ${actualType}`);
+        }
+        break;
+      case 'date':
+        if ((typeof input !== 'string' && validationType !== '[=dates]') || isNaN(Date.parse(input))) {
+          throw new ValidationError(`Input ${field.field} should be a valid date string, but got ${input}`);
+        } else if (validationType === '[=dates]' && !Array.isArray(input)) {
+          throw new ValidationError(`Input ${field.field} should be an array of date strings, but got ${input}`);
+        }
+        break;
+      case 'text-input':
+        if (typeof input !== 'string' && validationType !== '[=texts]') {
+          throw new ValidationError(`Input ${field.field} should be a string, but got ${actualType}`);
+        } else if (validationType === '[=texts]' && !Array.isArray(input)) {
+          throw new ValidationError(`Input ${field.field} should be an array of strings, but got ${actualType}`);
+        }
+        break;
+      case 'true-false':
+        if (typeof input !== 'boolean') {
+          throw new ValidationError(`Input ${field.field} should be a boolean, but got ${actualType}`);
+        }
+        break;
+    }
+  }
+
+  private validateCriteria(field: any, input: any): void {
+    const { dataType, type } = field;
+
+    switch (type || dataType) {
+      case 'number-input':
+        this.validateNumberCriteria(field, input);
+        break;
+      case 'date':
+        this.validateDateCriteria(field, input);
+        break;
+      case 'text-input':
+        this.validateTextCriteria(field, input);
+        break;
+    }
+  }
+
+  private validateNumberCriteria(field: any, input: number | number[]): void {
+    const { validationCriteria, validationType } = field;
+    const numberValues = validationCriteria
+      ? validationCriteria
+          .replace(/[\[\]]/g, '')
+          .split(',')
+          .map((val: string) => parseFloat(val.trim()))
+      : [];
+
+    const validationValue = parseFloat(validationCriteria) || 0;
+    const [minValue, maxValue] =
+      numberValues.length > 1 ? [numberValues[0], numberValues[numberValues.length - 1]] : [0, 10];
+
+    const numberInput = typeof input === 'number' ? parseFloat(input.toFixed(2)) : null;
+
+    switch (validationType) {
+      case '==':
+        if (numberInput !== parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must equal ${validationValue}`);
+        }
+        break;
+      case '!=':
+        if (numberInput === parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must not equal ${validationValue}`);
+        }
+        break;
+      case '>=':
+        if (numberInput < parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must be greater than or equal to ${validationValue}`);
+        }
+        break;
+      case '<=':
+        if (numberInput > parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must be less than or equal to ${validationValue}`);
+        }
+        break;
+      case '>':
+        if (numberInput <= parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must be greater than ${validationValue}`);
+        }
+        break;
+      case '<':
+        if (numberInput >= parseFloat(validationValue.toFixed(2))) {
+          throw new ValidationError(`Input ${field.field} must be less than ${validationValue}`);
+        }
+        break;
+      case '(num)':
+        if (numberInput <= minValue || numberInput >= maxValue) {
+          throw new ValidationError(`Input ${field.field} must be between ${minValue} and ${maxValue} (exclusive)`);
+        }
+        break;
+      case '[num]':
+        if (numberInput < minValue || numberInput > maxValue) {
+          throw new ValidationError(`Input ${field.field} must be between ${minValue} and ${maxValue} (inclusive)`);
+        }
+        break;
+      case '[=num]':
+        if (!numberValues.includes(numberInput)) {
+          throw new ValidationError(`Input ${field.field} must be one of: ${numberValues.join(', ')}`);
+        }
+        break;
+      case '[=nums]':
+        if (!Array.isArray(input) || !input.every((inp: number) => numberValues.includes(parseFloat(inp.toFixed(2))))) {
+          throw new ValidationError(
+            `Input ${field.field} must be an array with values from: ${numberValues.join(', ')}`,
+          );
+        }
+        break;
+    }
+  }
+
+  private validateDateCriteria(field: any, input: string | string[]): void {
+    const { validationCriteria, validationType } = field;
+    const dateValues = validationCriteria
+      ? validationCriteria
+          .replace(/[\[\]]/g, '')
+          .split(',')
+          .map((val: string) => new Date(val.trim()).getTime())
+      : [];
+
+    const dateValidationValue = new Date(validationCriteria).getTime() || new Date().getTime();
+    const [minDate, maxDate] =
+      dateValues.length > 1
+        ? [dateValues[0], dateValues[dateValues.length - 1]]
+        : [new Date().getTime(), new Date().setFullYear(new Date().getFullYear() + 1)];
+
+    const dateInput = typeof input === 'string' ? new Date(input).getTime() : null;
+
+    switch (validationType) {
+      case '==':
+        if (dateInput !== dateValidationValue) {
+          throw new ValidationError(`Input ${field.field} must equal ${new Date(dateValidationValue).toISOString()}`);
+        }
+        break;
+      case '!=':
+        if (dateInput === dateValidationValue) {
+          throw new ValidationError(
+            `Input ${field.field} must not equal ${new Date(dateValidationValue).toISOString()}`,
+          );
+        }
+        break;
+      case '>=':
+        if (dateInput < dateValidationValue) {
+          throw new ValidationError(
+            `Input ${field.field} must be on or after ${new Date(dateValidationValue).toISOString()}`,
+          );
+        }
+        break;
+      case '<=':
+        if (dateInput > dateValidationValue) {
+          throw new ValidationError(
+            `Input ${field.field} must be on or before ${new Date(dateValidationValue).toISOString()}`,
+          );
+        }
+        break;
+      case '>':
+        if (dateInput <= dateValidationValue) {
+          throw new ValidationError(
+            `Input ${field.field} must be after ${new Date(dateValidationValue).toISOString()}`,
+          );
+        }
+        break;
+      case '<':
+        if (dateInput >= dateValidationValue) {
+          throw new ValidationError(
+            `Input ${field.field} must be before ${new Date(dateValidationValue).toISOString()}`,
+          );
+        }
+        break;
+      case '(date)':
+        if (dateInput <= minDate || dateInput >= maxDate) {
+          throw new ValidationError(
+            `Input ${field.field} must be between ${new Date(minDate).toISOString()} and ${new Date(maxDate).toISOString()} (exclusive)`,
+          );
+        }
+        break;
+      case '[date]':
+        if (dateInput < minDate || dateInput > maxDate) {
+          throw new ValidationError(
+            `Input ${field.field} must be between ${new Date(minDate).toISOString()} and ${new Date(maxDate).toISOString()} (inclusive)`,
+          );
+        }
+        break;
+      case '[=date]':
+        if (!dateValues.includes(dateInput)) {
+          throw new ValidationError(
+            `Input ${field.field} must be one of: ${dateValues.map((d) => new Date(d).toISOString()).join(', ')}`,
+          );
+        }
+        break;
+      case '[=dates]':
+        if (!Array.isArray(input) || !input.every((inp: string) => dateValues.includes(new Date(inp).getTime()))) {
+          throw new ValidationError(
+            `Input ${field.field} must be an array with dates from: ${dateValues.map((d) => new Date(d).toISOString()).join(', ')}`,
+          );
+        }
+        break;
+    }
+  }
+
+  private validateTextCriteria(field: any, input: string | string[]): void {
+    const { validationCriteria, validationType } = field;
+
+    switch (validationType) {
+      case '==':
+        if (input !== validationCriteria) {
+          throw new ValidationError(`Input ${field.field} must equal "${validationCriteria}"`);
+        }
+        break;
+      case '!=':
+        if (input === validationCriteria) {
+          throw new ValidationError(`Input ${field.field} must not equal "${validationCriteria}"`);
+        }
+        break;
+      case 'regex':
+        if (typeof input === 'string') {
+          try {
+            const regex = new RegExp(validationCriteria);
+            if (!regex.test(input)) {
+              throw new ValidationError(`Input ${field.field} must match the pattern: ${validationCriteria}`);
+            }
+          } catch (e) {
+            throw new ValidationError(`Invalid regex pattern for ${field.field}: ${validationCriteria}`);
+          }
+          break;
+        }
+      case '[=text]':
+        if (typeof input === 'string') {
+          const validTexts = validationCriteria
+            .replace(/[\[\]]/g, '')
+            .split(',')
+            .map((val: string) => val.trim());
+          if (!validTexts.includes(input.trim())) {
+            throw new ValidationError(`Input ${field.field} must be one of: ${validTexts.join(', ')}`);
+          }
+          break;
+        }
+      case '[=texts]':
+        const validTextArray = validationCriteria
+          .replace(/[\[\]]/g, '')
+          .split(',')
+          .map((val: string) => val.trim());
+        const inputArray = Array.isArray(input)
+          ? input
+          : input
+              .replace(/[\[\]]/g, '')
+              .split(',')
+              .map((val) => val.trim());
+        if (!inputArray.every((inp: string) => validTextArray.includes(inp))) {
+          throw new ValidationError(
+            `Input ${field.field} must be on or many of the values from: ${validTextArray.join(', ')}`,
+          );
+        }
+        break;
+    }
+  }
+
+  validateOutput(outputSchema: any, output: any): void {
+    this.validateField(outputSchema, { output });
+  }
+}

--- a/src/api/decisions/validations/validations.service.ts
+++ b/src/api/decisions/validations/validations.service.ts
@@ -8,8 +8,18 @@ export class ValidationService {
       return;
     }
 
+    const errors: string[] = [];
+
     for (const field of ruleContent.fields) {
-      this.validateField(field, context);
+      try {
+        this.validateField(field, context);
+      } catch (e) {
+        errors.push(e.message);
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ValidationError(`${errors.join('; ')}`);
     }
   }
 
@@ -19,7 +29,7 @@ export class ValidationService {
     }
 
     if (!(field.field in context)) {
-        return;
+      return;
     }
 
     const input = context[field.field];

--- a/src/api/ruleData/ruleData.service.ts
+++ b/src/api/ruleData/ruleData.service.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import axios from 'axios';
@@ -125,6 +125,9 @@ export class RuleDataService {
     // If there is a rule draft, update that document specifically
     // This is necessary because we don't store the draft on the ruleData object directly
     // Instead it is stored elsewhere and linked to the ruleData via its id
+    if (ruleData.ruleDraft && typeof ruleData.ruleDraft === 'string') {
+      ruleData.ruleDraft = new Types.ObjectId(`${ruleData.ruleDraft}`);
+    }
     if (ruleData?.ruleDraft) {
       const newDraft = new this.ruleDraftModel(ruleData.ruleDraft);
       const savedDraft = await newDraft.save();

--- a/src/api/scenarioData/scenarioData.service.spec.ts
+++ b/src/api/scenarioData/scenarioData.service.spec.ts
@@ -421,7 +421,16 @@ describe('ScenarioDataService', () => {
 
       const results = await service.runDecisionsForScenarios(filepath, ruleContent);
       expect(results).toEqual({
-        [testObjectId.toString()]: { error: 'Decision execution error' },
+        [testObjectId.toString()]: {
+          expectedResults: {},
+          inputs: {
+            familyComposition: 'single',
+          },
+          outputs: null,
+          result: {},
+          resultMatch: false,
+          error: 'Decision execution error',
+        },
       });
     });
 
@@ -499,7 +508,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,2\nScenario 2,Fail,couple,3`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren,Error?\nScenario 1,Fail,single,2,\nScenario 2,Fail,couple,3,`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });
@@ -524,7 +533,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,\nScenario 2,Fail,couple,3`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren,Error?\nScenario 1,Fail,single,,\nScenario 2,Fail,couple,3,`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });
@@ -544,7 +553,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren\nScenario 1,Fail,single,2`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: numberOfChildren,Error?\nScenario 1,Fail,single,2,`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });
@@ -558,7 +567,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail)`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Error?\n`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });
@@ -577,7 +586,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail)\nScenario 1,Fail`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Error?\nScenario 1,Fail,`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });
@@ -597,7 +606,7 @@ describe('ScenarioDataService', () => {
 
       const csvContent = await service.getCSVForRuleRun(filepath, ruleContent);
 
-      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: input1,Input: input2\nScenario 1,Fail,"value, with, commas",value "with" quotes`;
+      const expectedCsvContent = `Scenario,Results Match Expected (Pass/Fail),Input: input1,Input: input2,Error?\nScenario 1,Fail,"value, with, commas",value "with" quotes,`;
 
       expect(csvContent.trim()).toBe(expectedCsvContent.trim());
     });

--- a/src/api/scenarioData/scenarioData.service.ts
+++ b/src/api/scenarioData/scenarioData.service.ts
@@ -119,11 +119,9 @@ export class ScenarioDataService {
     }
     const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleContent);
     const results: { [scenarioId: string]: any } = {};
-
     for (const scenario of scenarios as ScenarioDataDocument[]) {
       const formattedVariablesObject = reduceToCleanObj(scenario?.variables, 'name', 'value');
       const formattedExpectedResultsObject = reduceToCleanObj(scenario?.expectedResults, 'name', 'value');
-
       try {
         const decisionResult = await this.decisionsService.runDecision(
           ruleContent,
@@ -150,7 +148,15 @@ export class ScenarioDataService {
         results[scenario.title.toString()] = scenarioResult;
       } catch (error) {
         console.error(`Error running decision for scenario ${scenario._id}: ${error.message}`);
-        results[scenario._id.toString()] = { error: error.message };
+        const scenarioResult = {
+          inputs: formattedVariablesObject,
+          outputs: null,
+          expectedResults: formattedExpectedResultsObject || {},
+          result: {},
+          resultMatch: false,
+          error: error.message,
+        };
+        results[scenario._id ? scenario._id.toString() : scenario?.title.toString()] = scenarioResult;
       }
     }
     return results;
@@ -176,6 +182,7 @@ export class ScenarioDataService {
       ...this.prefixKeys(keys.inputs, 'Input'),
       ...this.prefixKeys(keys.expectedResults, 'Expected Result'),
       ...this.prefixKeys(keys.result, 'Result'),
+      'Error?',
     ];
 
     const rows = Object.entries(ruleRunResults).map(([scenarioName, data]) => [
@@ -184,6 +191,7 @@ export class ScenarioDataService {
       ...this.mapFields(data.inputs, keys.inputs),
       ...this.mapFields(data.expectedResults, keys.expectedResults),
       ...this.mapFields(data.result, keys.result),
+      data.error ? this.escapeCSVField(data.error) : '',
     ]);
 
     return [headers, ...rows].map((row) => row.join(',')).join('\n');
@@ -504,7 +512,17 @@ export class ScenarioDataService {
         };
       } catch (error) {
         console.error(`Error running decision for scenario ${title}: ${error.message}`);
-        return { title, scenarioResult: { error: error.message } };
+        return {
+          title,
+          scenarioResult: {
+            inputs: formattedVariablesObject,
+            outputs: null,
+            expectedResults: formattedExpectedResultsObject || {},
+            result: {},
+            resultMatch: false,
+            error: error.message,
+          },
+        };
       }
     });
 
@@ -544,6 +562,7 @@ export class ScenarioDataService {
         ...this.prefixKeys(keys.inputs, 'Input'),
         ...this.prefixKeys(keys.expectedResults, 'Expected Result'),
         ...this.prefixKeys(keys.result, 'Result'),
+        'Error?',
       ];
 
       const rows = Object.entries(ruleRunResults).map(([scenarioName, data]) => [
@@ -552,6 +571,7 @@ export class ScenarioDataService {
         ...this.mapFields(data.inputs, keys.inputs),
         ...this.mapFields(data.expectedResults, keys.expectedResults),
         ...this.mapFields(data.result, keys.result),
+        data.error ? this.escapeCSVField(data.error) : '',
       ]);
 
       return [headers, ...rows].map((row) => row.join(',')).join('\n');

--- a/src/utils/handleTrace.ts
+++ b/src/utils/handleTrace.ts
@@ -24,7 +24,8 @@ export const mapTraceToResult = (trace: TraceObject, ruleSchema: RuleSchema, typ
   const result: { [key: string]: any } = {};
   const schema = type === 'input' ? ruleSchema.inputs : ruleSchema.resultOutputs;
   for (const [key, value] of Object.entries(trace)) {
-    if (trace[key] && typeof trace[key] === 'object' && key !== '$' && key !== '$nodes') {
+    const keyExistsOnSchema = schema.some((item: any) => item.field === key);
+    if (trace[key] && typeof trace[key] === 'object' && key !== '$' && key !== '$nodes' && keyExistsOnSchema) {
       const newArray: any[] = [];
       const arrayName = key;
       for (const item in trace[key]) {
@@ -60,7 +61,6 @@ export const mapTraceToResult = (trace: TraceObject, ruleSchema: RuleSchema, typ
       }
     }
   }
-
   return result;
 };
 


### PR DESCRIPTION
- [x] Inputs are checked against the given validation data prior to rule run
- [x] Errors are thrown by the api regarding how the data does not match the required inputs.
- [x] Data is first validated for matching type, and then validated for matching the specific requirements of the field.
- [x] Errors are descriptive regarding the input requirements.
- [x] Integrated this error process into CSV generation/processing as well, so test scenarios processed by CSV fail and provide feedback in the 'Error?' column regarding any errors with input.
- [x] Fixed an additional bug regarding deletion handling and updates on the admin page introduced in https://github.com/bcgov/brms-api/pull/41.