### PR TITLE
Add Swagger Documentation to API.

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,14 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "introspectComments": true
+        }
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/mongoose": "^10.0.5",
         "@nestjs/platform-express": "^10.3.9",
+        "@nestjs/swagger": "^8.1.0",
         "axios": "^1.6.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -1789,6 +1790,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
@@ -1994,6 +2000,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/mongoose": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/mongoose/-/mongoose-10.0.5.tgz",
@@ -2063,6 +2088,43 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.1.0.tgz",
+      "integrity": "sha512-8hzH+r/31XshzXHC9vww4T0xjDAxMzvOaT1xAOvvY1LtXTWyNRCUP2iQsCYJOnnMrR+vydWjvRZiuB3hdvaHxA==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.6",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.18.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.3",
@@ -2164,6 +2226,12 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3065,8 +3133,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -6413,7 +6480,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8534,6 +8600,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/mongoose": "^10.0.5",
     "@nestjs/platform-express": "^10.3.9",
+    "@nestjs/swagger": "^8.1.0",
     "axios": "^1.6.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/api/decisions/decisions.controller.ts
+++ b/src/api/decisions/decisions.controller.ts
@@ -1,13 +1,26 @@
 import { Controller, Post, Query, Body, HttpException, HttpStatus } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { DecisionsService } from './decisions.service';
 import { EvaluateDecisionDto, EvaluateDecisionWithContentDto } from './dto/evaluate-decision.dto';
 import { ValidationError } from './validations/validation.error';
+import { ruleExample } from '../../examples/rule.example';
+import { decisionExample } from '../../examples/decision.example';
 
 @Controller('api/decisions')
 export class DecisionsController {
   constructor(private readonly decisionsService: DecisionsService) {}
 
   @Post('/evaluate')
+  @ApiOperation({ summary: 'Evaluate a decision by its rule content' })
+  @ApiBody({
+    type: EvaluateDecisionWithContentDto,
+    description: 'The decision rule content, decision context, and trace status.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Decision evaluated successfully',
+    schema: { example: decisionExample },
+  })
   async evaluateDecisionByContent(@Body() { ruleContent, context, trace }: EvaluateDecisionWithContentDto) {
     try {
       return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace });
@@ -21,6 +34,22 @@ export class DecisionsController {
   }
 
   @Post('/evaluateByFile')
+  @ApiOperation({ summary: 'Evaluate a decision by rule file name' })
+  @ApiQuery({
+    name: 'ruleFileName',
+    description: 'The path to the rule file to evaluate',
+    example: ruleExample.filepath,
+    required: true,
+  })
+  @ApiBody({
+    type: EvaluateDecisionDto,
+    description: 'The decision context, including variable properties and values, and trace status.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Decision evaluated successfully',
+    schema: { example: decisionExample },
+  })
   async evaluateDecisionByFile(
     @Query('ruleFileName') ruleFileName: string,
     @Body() { context, trace }: EvaluateDecisionDto,

--- a/src/api/decisions/dto/evaluate-decision.dto.ts
+++ b/src/api/decisions/dto/evaluate-decision.dto.ts
@@ -1,15 +1,32 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import { IsBoolean, IsObject } from 'class-validator';
 import { RuleContent } from 'src/api/ruleMapping/ruleMapping.interface';
+import { ruleContentExample, ruleInputs } from '../../../examples/rule.example';
 
+@ApiSchema({ description: 'DTO for evaluating a decision' })
 export class EvaluateDecisionDto {
+  @ApiProperty({
+    example: ruleInputs,
+    description: 'The context object containing input data for the decision evaluation.',
+  })
   @IsObject()
   context: object;
 
+  @ApiProperty({
+    example: true,
+    description: 'Whether to include execution trace information in the response.',
+  })
   @IsBoolean()
   trace: boolean;
 }
 
+@ApiSchema({ description: 'DTO for evaluating a decision with rule content' })
 export class EvaluateDecisionWithContentDto extends EvaluateDecisionDto {
+  @ApiProperty({
+    example: ruleContentExample,
+    description:
+      'The rule content containing nodes and edges that define the decision logic. The nodes represent the decision logic components and the edges represent the connections between them.',
+  })
   @IsObject()
   ruleContent: RuleContent;
 }

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -1,19 +1,41 @@
 import { Controller, Get, Query, Res, HttpException, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { Response } from 'express';
 import { DocumentsService } from './documents.service';
+import { ruleExample, ruleList, ruleContentExample } from '../../examples/rule.example';
 
 @Controller('api/documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
 
   @Get('/all')
-  // Get a list of all the JSON files in the rules directory
+  @ApiOperation({ summary: 'Get a list of all JSON rule files in the rules directory' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of rule files retrieved successfully',
+    schema: {
+      example: ruleList,
+    },
+  })
   async getAllDocuments() {
     return await this.documentsService.getAllJSONFiles();
   }
 
   @Get('/')
-  // Get a specific JSON file from the rules directory
+  @ApiOperation({ summary: 'Get a specific rule file by filename' })
+  @ApiQuery({
+    name: 'ruleFileName',
+    description: 'The path to the rule file to retrieve',
+    example: ruleExample.filepath,
+    required: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule file retrieved successfully',
+    schema: {
+      example: ruleContentExample,
+    },
+  })
   async getRuleFile(@Query('ruleFileName') ruleFileName: string, @Res() res: Response) {
     const fileContent = await this.documentsService.getFileContent(ruleFileName);
 

--- a/src/api/klamm/klamm.controller.ts
+++ b/src/api/klamm/klamm.controller.ts
@@ -1,22 +1,60 @@
 import { Controller, Get, Query, Param } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { KlammField } from './klamm';
 import { KlammService } from './klamm.service';
+import { klammResponseExamples } from '../../examples/klammRule.example';
 
 @Controller('api/klamm')
 export class KlammController {
   constructor(private readonly klammService: KlammService) {}
 
   @Get('/brefields')
+  @ApiOperation({ summary: 'Search KLAMM BRE fields by search text' })
+  @ApiQuery({
+    name: 'searchText',
+    description: 'Text to search for in field names',
+    required: true,
+    example: 'isEligible',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'BRE fields retrieved successfully',
+    schema: {
+      example: klammResponseExamples.breFields,
+    },
+  })
   async getKlammBREFields(@Query('searchText') searchText: string) {
     return await this.klammService.getKlammBREFields(searchText);
   }
 
   @Get('/brerules')
+  @ApiOperation({ summary: 'Get all KLAMM fields and rules' })
+  @ApiResponse({
+    status: 200,
+    description: 'All KLAMM fields retrieved successfully',
+    schema: {
+      example: klammResponseExamples.breRules,
+    },
+  })
   async getKlammBRERules() {
     return await this.klammService._getAllKlammFields();
   }
 
   @Get('/brefield/:fieldName')
+  @ApiOperation({ summary: 'Get KLAMM field details by field name' })
+  @ApiParam({
+    name: 'fieldName',
+    description: 'Name of the KLAMM field to retrieve',
+    required: true,
+    example: 'isEligible',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'KLAMM field retrieved successfully',
+    schema: {
+      example: klammResponseExamples.breFields,
+    },
+  })
   async getKlammBREFieldFromName(@Param('fieldName') fieldName: string): Promise<KlammField[]> {
     return await this.klammService.getKlammBREFieldFromName(fieldName);
   }

--- a/src/api/ruleData/dto/pagination.dto.ts
+++ b/src/api/ruleData/dto/pagination.dto.ts
@@ -1,36 +1,82 @@
-import { IsOptional, IsString, IsObject } from 'class-validator';
+import { IsOptional, IsString, IsObject, IsArray } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+class FiltersDto {
+  @ApiProperty({
+    type: [String],
+    description: 'Array of file paths',
+    example: ['general-supplements', 'health-supplements'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  filepath?: string[];
+}
 
 export class PaginationDto {
+  @ApiProperty({
+    example: 1,
+    description: 'Page number for pagination',
+  })
   @IsOptional()
   @IsString()
   page?: number;
 
+  @ApiProperty({
+    example: 10,
+    description: 'Number of items per page',
+  })
   @IsOptional()
   @IsString()
   pageSize?: number;
 
+  @ApiProperty({
+    example: 'filepath',
+    description: 'Field to sort by',
+  })
   @IsOptional()
   @IsString()
   sortField?: string;
 
+  @ApiProperty({
+    example: 'ascend',
+    enum: ['ascend', 'descend'],
+    description: 'Sort order direction',
+  })
   @IsOptional()
   @IsString()
   sortOrder?: 'ascend' | 'descend';
 
+  @ApiProperty({
+    type: FiltersDto,
+    description: 'Filter criteria',
+    example: { filepath: ['general-supplements', 'health-supplements'] },
+  })
   @IsOptional()
-  @IsObject()
-  @Type(() => Object)
-  filters?: Record<string, any>;
+  filters?: FiltersDto;
 
+  @ApiProperty({
+    example: 'winter',
+    description: 'Search term for filtering results',
+  })
   @IsOptional()
   @IsString()
   searchTerm?: string;
 }
 
 export class CategoryObject {
+  @ApiProperty({
+    example: 'general-supplements',
+    description: 'Category name',
+  })
   @IsObject()
   @Type(() => Object)
   text: string;
+
+  @ApiProperty({
+    example: 'general-supplements',
+    description: 'Category Value',
+  })
   value: string;
 }

--- a/src/api/ruleData/ruleData.controller.ts
+++ b/src/api/ruleData/ruleData.controller.ts
@@ -1,14 +1,24 @@
 import { Controller, Get, Param, Post, Body, Put, Delete, HttpException, HttpStatus, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { RuleDataService } from './ruleData.service';
 import { RuleData } from './ruleData.schema';
 import { RuleDraft } from './ruleDraft.schema';
 import { CategoryObject, PaginationDto } from './dto/pagination.dto';
+import { ruleExample, ruleExample2, ruleList, ruleContentExample } from '../../examples/rule.example';
 
 @Controller('api/ruleData')
 export class RuleDataController {
   constructor(private readonly ruleDataService: RuleDataService) {}
 
   @Get('/list')
+  @ApiOperation({ summary: 'Get all rules data with pagination' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of rules data retrieved successfully',
+    schema: {
+      example: { data: [ruleExample, ruleExample2], total: 2, categories: ruleList },
+    },
+  })
   async getAllRulesData(
     @Query() query?: PaginationDto,
   ): Promise<{ data: RuleData[]; total: number; categories: Array<CategoryObject> }> {
@@ -21,6 +31,13 @@ export class RuleDataController {
   }
 
   @Get('/draft/:ruleId')
+  @ApiOperation({ summary: 'Get a rule draft ID from a given rule ID' })
+  @ApiParam({ name: 'ruleId', description: 'The ID of the rule', example: ruleExample._id })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule draft retrieved successfully',
+    example: '676362648cb89c8b157adb5a',
+  })
   async getRuleDraft(@Param('ruleId') ruleId: string): Promise<RuleDraft> {
     try {
       return await this.ruleDataService.getRuleDataWithDraft(ruleId);
@@ -30,6 +47,13 @@ export class RuleDataController {
   }
 
   @Get('/:ruleId')
+  @ApiOperation({ summary: 'Get a rule by ID' })
+  @ApiParam({ name: 'ruleId', description: 'The ID of the rule', example: ruleExample._id })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule data retrieved successfully',
+    type: RuleData,
+  })
   async getRuleData(@Param('ruleId') ruleId: string): Promise<RuleData> {
     try {
       return await this.ruleDataService.getRuleData(ruleId);
@@ -39,6 +63,26 @@ export class RuleDataController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create a new rule' })
+  @ApiBody({
+    type: RuleData,
+    schema: {
+      examples: {
+        newRule: {
+          value: {
+            title: ruleExample.title,
+            filepath: ruleExample.filepath,
+            ruleDraft: ruleContentExample,
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Rule created successfully',
+    type: RuleData,
+  })
   async createRuleData(@Body() ruleData: RuleData): Promise<RuleData> {
     try {
       return await this.ruleDataService.createRuleData(ruleData);
@@ -48,6 +92,14 @@ export class RuleDataController {
   }
 
   @Put('/:ruleId')
+  @ApiOperation({ summary: 'Update an existing rule' })
+  @ApiParam({ name: 'ruleId', description: 'The ID of the rule to update', example: ruleExample._id })
+  @ApiBody({ type: RuleData })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule updated successfully',
+    type: RuleData,
+  })
   async updateRuleData(@Param('ruleId') ruleId: string, @Body() ruleData: RuleData): Promise<RuleData> {
     try {
       return await this.ruleDataService.updateRuleData(ruleId, ruleData);
@@ -57,6 +109,12 @@ export class RuleDataController {
   }
 
   @Delete('/:ruleId')
+  @ApiOperation({ summary: 'Delete a rule' })
+  @ApiParam({ name: 'ruleId', description: 'The ID of the rule to delete', example: ruleExample._id })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule deleted successfully',
+  })
   async deleteRuleData(@Param('ruleId') ruleId: string): Promise<void> {
     try {
       await this.ruleDataService.deleteRuleData(ruleId);

--- a/src/api/ruleData/ruleData.schema.ts
+++ b/src/api/ruleData/ruleData.schema.ts
@@ -1,28 +1,58 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { RuleDraftDocument } from './ruleDraft.schema';
+import { ApiProperty } from '@nestjs/swagger';
+import { ruleExample } from '../../examples/rule.example';
 
 @Schema()
 export class RuleData {
-  @Prop({ required: true, description: 'The GoRules ID' })
+  @ApiProperty({
+    description: 'The rule ID within the BRM App',
+    example: ruleExample._id,
+  })
+  @Prop({ required: true })
   _id: string;
 
-  @Prop({ unique: true, description: 'A unique name currently derived from the filepath' })
+  @ApiProperty({
+    description: 'A unique name derived from the filepath',
+    example: ruleExample.name,
+  })
+  @Prop({ unique: true })
   name: string;
 
-  @Prop({ description: 'The title of the rule' })
+  @ApiProperty({
+    description: 'The title of the rule',
+    example: ruleExample.title,
+  })
+  @Prop()
   title: string;
 
-  @Prop({ required: true, description: 'The filepath of the JSON file containing the rule' })
+  @ApiProperty({
+    description: 'The filepath of the JSON file containing the rule',
+    example: ruleExample.filepath,
+  })
+  @Prop({ required: true })
   filepath: string;
 
-  @Prop({ type: Types.ObjectId, description: 'Draft of updated rule content', ref: 'RuleDraft' })
+  @ApiProperty({
+    description: 'Id for the draft of updated rule content',
+    example: ruleExample.ruleDraft,
+  })
+  @Prop({ type: Types.ObjectId })
   ruleDraft?: RuleDraftDocument | Types.ObjectId;
 
-  @Prop({ description: 'The name of the branch on github associated with this file' })
+  @ApiProperty({
+    description: 'The name of the branch on github associated with this file',
+    example: ruleExample.reviewBranch,
+  })
+  @Prop()
   reviewBranch?: string;
 
-  @Prop({ description: 'If the rule has been published' })
+  @ApiProperty({
+    description: 'If the rule has been published',
+    example: ruleExample.isPublished,
+  })
+  @Prop()
   isPublished?: boolean;
 }
 

--- a/src/api/ruleData/ruleData.service.spec.ts
+++ b/src/api/ruleData/ruleData.service.spec.ts
@@ -289,13 +289,24 @@ describe('RuleDataService', () => {
       await service.getAllRuleData({
         page: 1,
         pageSize: 10,
-        filters: { status: ['active', 'pending'] },
+        filters: { filepath: ['docs/category1', 'docs/category2'] },
       });
 
       expect(MockRuleDataModel.find).toHaveBeenCalledWith({
         $and: [
           {
-            status: { $in: ['active', 'pending'] },
+            $or: [
+              {
+                filepath: {
+                  $regex: new RegExp('(^docs/category1/|/docs/category1/)', 'i'),
+                },
+              },
+              {
+                filepath: {
+                  $regex: new RegExp('(^docs/category2/|/docs/category2/)', 'i'),
+                },
+              },
+            ],
           },
         ],
       });
@@ -305,13 +316,19 @@ describe('RuleDataService', () => {
       await service.getAllRuleData({
         page: 1,
         pageSize: 10,
-        filters: { isPublished: true },
+        filters: { filepath: ['docs/general'] },
       });
 
       expect(MockRuleDataModel.find).toHaveBeenCalledWith({
         $and: [
           {
-            isPublished: true,
+            $or: [
+              {
+                filepath: {
+                  $regex: new RegExp('(^docs/general/|/docs/general/)', 'i'),
+                },
+              },
+            ],
           },
         ],
       });
@@ -321,7 +338,7 @@ describe('RuleDataService', () => {
       await service.getAllRuleData({
         page: 1,
         pageSize: 10,
-        filters: { status: null, isPublished: undefined },
+        filters: {},
       });
 
       expect(MockRuleDataModel.find).toHaveBeenCalledWith({});

--- a/src/api/ruleData/ruleDraft.schema.ts
+++ b/src/api/ruleData/ruleDraft.schema.ts
@@ -1,9 +1,16 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiSchema, ApiProperty } from '@nestjs/swagger';
 import { Document, Schema as MongooseSchema } from 'mongoose';
+import { ruleContentExample } from '../../examples/rule.example';
 
 @Schema()
+@ApiSchema({ description: 'Draft of updated rule content' })
 export class RuleDraft {
-  @Prop({ type: MongooseSchema.Types.Mixed, description: 'Draft of updated rule content' })
+  @ApiProperty({
+    description: 'The content of a rule draft.',
+    example: ruleContentExample,
+  })
+  @Prop({ type: MongooseSchema.Types.Mixed })
   content: object;
 }
 

--- a/src/api/ruleMapping/dto/evaluate-rulemapping.dto.ts
+++ b/src/api/ruleMapping/dto/evaluate-rulemapping.dto.ts
@@ -1,13 +1,47 @@
 import { IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Edge, Node, TraceObject, TraceObjectEntry } from '../ruleMapping.interface';
+import { ApiExtraModels, ApiProperty, ApiSchema } from '@nestjs/swagger';
+import { Edge, Node, TraceObject, TraceObjectEntry, NodeContent } from '../ruleMapping.interface';
+import { ruleContentExample } from '../../../examples/rule.example';
+import { decisionExample } from '../../../examples/decision.example';
 
 export class EdgeClass implements Edge {
+  @ApiProperty({
+    description: 'Unique identifier for the edge',
+    example: 'aed0501a-8138-4cfa-b7f3-7b8eee7807c9',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'The type of the edge',
+    example: 'edge',
+  })
   type: string;
+
+  @ApiProperty({
+    description: 'ID of the target node',
+    example: 'd5c6c7df-dc16-47d4-b84d-e005893ee2d1',
+  })
   targetId: string;
+
+  @ApiProperty({
+    description: 'ID of the source node',
+    example: '533fcf7b-c45d-45fd-b1e9-3099217d9ded',
+  })
   sourceId: string;
+
+  @ApiProperty({
+    description: 'Handle identifier for the source connection point',
+    example: '38203cc4-5089-4ed7-b19c-58a99b65e545',
+    required: false,
+  })
   sourceHandle?: string;
+
+  @ApiProperty({
+    description: 'Handle identifier for the target connection point',
+    example: '7b088ca1-2314-45ec-835c-c38e66f7cb5c',
+    required: false,
+  })
   targetHandle?: string;
 
   constructor(
@@ -27,12 +61,68 @@ export class EdgeClass implements Edge {
   }
 }
 
-export class TraceObjectEntryClass implements TraceObjectEntry {
+export class NodeClass implements Node {
+  @ApiProperty({
+    description: 'Unique identifier for the node',
+    example: '8ac97728-c53d-441b-8c4f-cbce96bbbfb1',
+  })
   id: string;
+
+  @ApiProperty({
+    description: 'Type of the node',
+    example: 'inputNode',
+  })
+  type: string;
+
+  @ApiProperty({
+    description: 'Content of the node',
+    example: ruleContentExample.nodes[0].content,
+  })
+  content: NodeContent | string;
+
+  constructor(id: string, type: string, content: NodeContent | string) {
+    this.id = id;
+    this.type = type;
+    this.content = content;
+  }
+}
+
+@ApiExtraModels()
+@ApiSchema({ description: 'Trace details from rule run' })
+export class TraceObjectEntryClass implements TraceObjectEntry {
+  @ApiProperty({
+    example: 'bd7103da-9a6e-4fbd-ba14-12008e3cd61c',
+    description: 'Unique identifier for the trace entry',
+  })
+  id: string;
+
+  @ApiProperty({
+    example: 'Calculate Age',
+    description: 'Name of the operation',
+  })
   name: string;
+
+  @ApiProperty({
+    description: 'Input data for the operation',
+  })
   input: any;
+
+  @ApiProperty({
+    description: 'Output data from the operation',
+  })
   output: any;
+
+  @ApiProperty({
+    example: '207.958µs',
+    description: 'Execution time of the operation',
+    required: false,
+  })
   performance?: string;
+
+  @ApiProperty({
+    description: 'Additional trace information',
+    required: false,
+  })
   traceData?: any;
 
   constructor(id: string, name: string, input: any, output: any, performance?: string, traceData?: any) {
@@ -45,6 +135,7 @@ export class TraceObjectEntryClass implements TraceObjectEntry {
   }
 }
 
+@ApiSchema({ description: 'Trace information from the rule execution' })
 export class TraceObjectClass implements TraceObject {
   [key: string]: TraceObjectEntryClass;
 
@@ -54,11 +145,21 @@ export class TraceObjectClass implements TraceObject {
 }
 
 export class EvaluateRuleMappingDto {
+  @ApiProperty({
+    description: 'Array of nodes representing the rule mapping',
+    type: [NodeClass],
+    example: ruleContentExample.nodes,
+  })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => Node)
+  @Type(() => NodeClass)
   nodes: Node[];
 
+  @ApiProperty({
+    description: 'Array of edges connecting the nodes',
+    type: [EdgeClass],
+    example: ruleContentExample.edges,
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => EdgeClass)
@@ -66,6 +167,11 @@ export class EvaluateRuleMappingDto {
 }
 
 export class EvaluateRuleRunSchemaDto {
+  @ApiProperty({
+    type: TraceObjectClass,
+    description: 'Trace information from the rule execution',
+    example: decisionExample.trace,
+  })
   @ValidateNested()
   @Type(() => TraceObjectClass)
   trace: TraceObject;

--- a/src/api/ruleMapping/ruleMapping.controller.ts
+++ b/src/api/ruleMapping/ruleMapping.controller.ts
@@ -2,6 +2,9 @@ import { Controller, Res, Post, Body, HttpException, HttpStatus } from '@nestjs/
 import { RuleMappingService, InvalidRuleContent } from './ruleMapping.service';
 import { Response } from 'express';
 import { EvaluateRuleRunSchemaDto, EvaluateRuleMappingDto } from './dto/evaluate-rulemapping.dto';
+import { ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { ruleContentExample, ruleExample, ruleInputMetadata, ruleOutputMetadata } from '../../examples/rule.example';
+import { decisionExample } from '../../examples/decision.example';
 
 @Controller('api/rulemap')
 export class RuleMappingController {
@@ -9,6 +12,25 @@ export class RuleMappingController {
 
   // Map a rule file to its unique inputs, and all outputs
   @Post('/')
+  @ApiOperation({ summary: 'Map a rule file to its unique inputs, and all outputs' })
+  @ApiBody({
+    schema: {
+      example: {
+        filepath: ruleExample.filepath,
+        ruleContent: ruleContentExample,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Rule schema mapping generated successfully',
+    schema: {
+      example: {
+        inputs: ruleInputMetadata,
+        resultOutputs: ruleOutputMetadata,
+      },
+    },
+  })
   async getRuleSchema(
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: EvaluateRuleMappingDto,
@@ -31,6 +53,20 @@ export class RuleMappingController {
 
   // Map a rule to its unique inputs, and all outputs
   @Post('/evaluate')
+  @ApiOperation({ summary: 'Evaluate rule mapping' })
+  @ApiBody({ type: EvaluateRuleMappingDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Rule mapping evaluated successfully',
+    schema: {
+      example: {
+        result: {
+          inputs: ruleInputMetadata,
+          resultOutputs: ruleOutputMetadata,
+        },
+      },
+    },
+  })
   async evaluateRuleMap(@Body() ruleContent: EvaluateRuleMappingDto) {
     try {
       const result = await this.ruleMappingService.inputOutputSchema(ruleContent);
@@ -46,6 +82,17 @@ export class RuleMappingController {
 
   // Map a rule to its unique inputs, and all outputs, based on the trace data of a rule run
   @Post('/rulerunschema')
+  @ApiOperation({ summary: 'Map a rule to its unique inputs, and all outputs, based on the trace data of a rule run' })
+  @ApiBody({ type: EvaluateRuleRunSchemaDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Rule schema evaluated successfully',
+    schema: {
+      example: {
+        result: decisionExample.trace,
+      },
+    },
+  })
   async evaluateRuleSchema(@Body() { trace }: EvaluateRuleRunSchemaDto) {
     try {
       if (!trace) {
@@ -64,6 +111,24 @@ export class RuleMappingController {
 
   // Map a rule file using only the rule content
   @Post('/generateFromRuleContent')
+  @ApiOperation({ summary: 'Generate rule mapping from rule content' })
+  @ApiBody({
+    schema: {
+      example: {
+        ruleContent: ruleContentExample,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Rule mapping generated successfully',
+    schema: {
+      example: {
+        inputs: ruleInputMetadata,
+        resultOutputs: ruleOutputMetadata,
+      },
+    },
+  })
   async generateWithoutInputOutputNodes(
     @Body('ruleContent') ruleContent: EvaluateRuleMappingDto,
     @Res() res: Response,

--- a/src/api/scenarioData/dto/create-scenario.dto.ts
+++ b/src/api/scenarioData/dto/create-scenario.dto.ts
@@ -1,31 +1,69 @@
 import { IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { Variable } from '../scenarioData.schema';
+import { ApiProperty } from '@nestjs/swagger';
+import { variableExamples, scenarioExample } from '../../../examples/scenario.example';
 
 export class VariableClass implements Variable {
+  @ApiProperty({
+    description: 'The name of the variable',
+    example: variableExamples[0].name,
+  })
   name: string;
+
+  @ApiProperty({
+    description: 'The value of the variable',
+    example: variableExamples[0].value,
+  })
   value: any;
+
+  @ApiProperty({
+    description: 'The data type of the variable',
+    example: variableExamples[0].type,
+  })
   type: string;
 }
 
 export class CreateScenarioDto {
+  @ApiProperty({
+    description: 'The title of the scenario',
+    example: scenarioExample.title,
+  })
   @IsNotEmpty()
   @IsString()
   title: string;
 
+  @ApiProperty({
+    description: 'The unique identifier of the rule the scenario is attached to',
+    example: scenarioExample.ruleID,
+  })
   @IsNotEmpty()
   @IsString()
   ruleID: string;
 
+  @ApiProperty({
+    type: [VariableClass],
+    description: 'Array of input variables for the scenario',
+    example: variableExamples,
+  })
   @IsNotEmpty()
   @ValidateNested({ each: true })
   @Type(() => VariableClass)
   variables: VariableClass[];
 
+  @ApiProperty({
+    type: [VariableClass],
+    description: 'Array of expected result outputs for the scenario',
+    example: scenarioExample.expectedResults,
+  })
   @ValidateNested({ each: true })
   @Type(() => VariableClass)
   expectedResults: VariableClass[];
 
+  @ApiProperty({
+    description: 'The filepath to the rule definition',
+    example: scenarioExample.filepath,
+  })
   @IsNotEmpty()
   @IsString()
   filepath: string;

--- a/src/api/scenarioData/scenarioData.schema.ts
+++ b/src/api/scenarioData/scenarioData.schema.ts
@@ -1,5 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
+import { ApiProperty } from '@nestjs/swagger';
+import { variableExamples, scenarioExample, expectedResultsExample } from '../../examples/scenario.example';
 
 export type ScenarioDataDocument = ScenarioData & Document;
 export interface Variable {
@@ -10,12 +12,24 @@ export interface Variable {
 
 @Schema()
 export class VariableSchema {
+  @ApiProperty({
+    description: 'The name of the variable',
+    example: variableExamples[0].name,
+  })
   @Prop({ required: true, type: String })
   name: string;
 
+  @ApiProperty({
+    description: 'The value of the variable',
+    example: variableExamples[0].value,
+  })
   @Prop({ required: true, type: {} })
   value: any;
 
+  @ApiProperty({
+    description: 'The data type of the variable',
+    example: variableExamples[0].type,
+  })
   @Prop({ required: false, type: String, default: '' })
   type: string;
 }
@@ -32,9 +46,17 @@ VariableModelSchema.pre<Variable>('save', function (next) {
 
 @Schema()
 export class ScenarioData {
+  @ApiProperty({
+    description: 'The title of the scenario',
+    example: scenarioExample.title,
+  })
   @Prop({ description: 'The title of the scenario' })
   title: string;
 
+  @ApiProperty({
+    description: 'The unique identifier of the rule the scenario is attached to',
+    example: scenarioExample.ruleID,
+  })
   @Prop({
     ref: 'RuleData',
     required: true,
@@ -42,6 +64,11 @@ export class ScenarioData {
   })
   ruleID: string;
 
+  @ApiProperty({
+    type: [VariableSchema],
+    description: 'Array of input variables for the scenario',
+    example: variableExamples,
+  })
   @Prop({
     required: true,
     description: 'The variables of the scenario',
@@ -49,6 +76,11 @@ export class ScenarioData {
   })
   variables: Variable[];
 
+  @ApiProperty({
+    type: [VariableSchema],
+    description: 'Array of expected result outputs for the scenario',
+    example: expectedResultsExample,
+  })
   @Prop({
     required: false,
     description: 'The expected result of the scenario',
@@ -56,6 +88,10 @@ export class ScenarioData {
   })
   expectedResults: Variable[];
 
+  @ApiProperty({
+    description: 'The filepath to the rule definition',
+    example: scenarioExample.filepath,
+  })
   @Prop({ required: true, description: 'The filename of the JSON file containing the rule' })
   filepath: string;
 }

--- a/src/examples/decision.example.ts
+++ b/src/examples/decision.example.ts
@@ -1,0 +1,207 @@
+import { ruleOutputs } from './rule.example';
+
+export const decisionExample = {
+  performance: '2.656583ms',
+  result: ruleOutputs,
+  trace: {
+    'bd7103da-9a6e-4fbd-ba14-12008e3cd61c': {
+      id: 'bd7103da-9a6e-4fbd-ba14-12008e3cd61c',
+      name: 'Should Calculate Supplement',
+      input: {
+        $: {
+          $nodes: {
+            IsEligible: {
+              isEligible: true,
+            },
+            'Winter Supplement Request': {
+              familyComposition: 'single',
+              familyUnitInPayForDecember: true,
+              numberOfChildren: 4,
+            },
+          },
+          familyComposition: 'single',
+          familyUnitInPayForDecember: true,
+          isEligible: true,
+          numberOfChildren: 4,
+        },
+        $nodes: {
+          IsEligible: {
+            isEligible: true,
+          },
+          'Winter Supplement Request': {
+            familyComposition: 'single',
+            familyUnitInPayForDecember: true,
+            numberOfChildren: 4,
+          },
+        },
+        familyComposition: 'single',
+        familyUnitInPayForDecember: true,
+        isEligible: true,
+        numberOfChildren: 4,
+      },
+      output: {
+        $: {
+          $nodes: {
+            IsEligible: {
+              isEligible: true,
+            },
+            'Winter Supplement Request': {
+              familyComposition: 'single',
+              familyUnitInPayForDecember: true,
+              numberOfChildren: 4,
+            },
+          },
+          familyComposition: 'single',
+          familyUnitInPayForDecember: true,
+          isEligible: true,
+          numberOfChildren: 4,
+        },
+        $nodes: {
+          IsEligible: {
+            isEligible: true,
+          },
+          'Winter Supplement Request': {
+            familyComposition: 'single',
+            familyUnitInPayForDecember: true,
+            numberOfChildren: 4,
+          },
+        },
+        familyComposition: 'single',
+        familyUnitInPayForDecember: true,
+        isEligible: true,
+        numberOfChildren: 4,
+      },
+      performance: '207.958µs',
+      traceData: {
+        statements: [
+          {
+            id: '38203cc4-5089-4ed7-b19c-58a99b65e545',
+          },
+        ],
+      },
+    },
+    'd5e41add-1cb0-4e32-8667-ffd548e523bf': {
+      id: 'd5e41add-1cb0-4e32-8667-ffd548e523bf',
+      name: 'Child Calculation',
+      input: {
+        familyComposition: 'single',
+        familyUnitInPayForDecember: true,
+        isEligible: true,
+        numberOfChildren: 4,
+      },
+      output: {
+        childrenAmount: 80,
+      },
+      performance: '55.417µs',
+      traceData: {
+        index: 0,
+        reference_map: {},
+        rule: {
+          _id: '722b3945-02f5-4210-a9e4-b496d7d9438b',
+          'numberOfChildren[4513898e-c063-4670-a99a-804148934985]': '',
+        },
+      },
+    },
+    '7b088ca1-2314-45ec-835c-c38e66f7cb5c': {
+      id: '7b088ca1-2314-45ec-835c-c38e66f7cb5c',
+      name: 'IsEligible',
+      input: {
+        familyComposition: 'single',
+        familyUnitInPayForDecember: true,
+        numberOfChildren: 4,
+      },
+      output: {
+        isEligible: true,
+      },
+      performance: '1.365208ms',
+      traceData: {
+        isEligible: {
+          result: 'true',
+        },
+      },
+    },
+    '84cf05d5-9ef3-4e83-bb7c-2b686e6b7815': {
+      id: '84cf05d5-9ef3-4e83-bb7c-2b686e6b7815',
+      name: 'Total Supplement',
+      input: {
+        baseAmount: 120,
+        childrenAmount: 80,
+      },
+      output: {
+        supplementAmount: 200,
+      },
+      performance: '11.792µs',
+      traceData: {
+        index: 0,
+        reference_map: {},
+        rule: {
+          _id: 'aa135592-8426-42ae-8d23-4512caeea78e',
+          'baseAmount[6abe1cb3-a3da-4770-abdc-25de26f96a88]': '',
+          'childrenAmount[dc3e0c07-45e0-4220-ba8e-f3d654be8f0a]': '',
+        },
+      },
+    },
+    '8ac97728-c53d-441b-8c4f-cbce96bbbfb1': {
+      id: '8ac97728-c53d-441b-8c4f-cbce96bbbfb1',
+      name: 'Winter Supplement Request',
+      input: null,
+      output: null,
+    },
+    '86049028-7a4f-4b79-a1b1-025b98061ee0': {
+      id: '86049028-7a4f-4b79-a1b1-025b98061ee0',
+      name: 'Winter Supplement Response',
+      input: null,
+      output: null,
+    },
+    'c3ab217c-22fa-4896-8f29-4a359e12f483': {
+      id: 'c3ab217c-22fa-4896-8f29-4a359e12f483',
+      name: 'Spouse Calculation',
+      input: {
+        familyComposition: 'single',
+        familyUnitInPayForDecember: true,
+        isEligible: true,
+        numberOfChildren: 4,
+      },
+      output: {
+        baseAmount: 120,
+      },
+      performance: '18.042µs',
+      traceData: {
+        index: 0,
+        reference_map: {},
+        rule: {
+          _id: '741c1d33-0606-4b95-a64b-b27bb9800820',
+          'familyComposition[3991b5b8-b68c-493d-a31b-226a0756ff28]': '"single"',
+          'numberOfChildren[33d4d4d1-a243-4d7f-8e0c-f73faaeb6cc1]': '$ > 0',
+        },
+      },
+    },
+  },
+};
+
+export const decisionResultExample = {
+  inputs: {
+    familyComposition: 'single',
+    familyUnitInPayForDecember: true,
+    numberOfChildren: 4,
+  },
+  outputs: {
+    baseAmount: 120,
+    childrenAmount: 80,
+    supplementAmount: 200,
+    isEligible: true,
+  },
+  expectedResults: {
+    baseAmount: 120,
+    childrenAmount: 80,
+    isEligible: true,
+    supplementAmount: 200,
+  },
+  result: {
+    baseAmount: 120,
+    childrenAmount: 80,
+    isEligible: true,
+    supplementAmount: 200,
+  },
+  resultMatch: true,
+};

--- a/src/examples/exampleRule.json
+++ b/src/examples/exampleRule.json
@@ -1,0 +1,344 @@
+{
+  "contentType": "application/vnd.gorules.decision",
+  "nodes": [
+    {
+      "id": "8ac97728-c53d-441b-8c4f-cbce96bbbfb1",
+      "name": "Winter Supplement Request",
+      "type": "inputNode",
+      "position": {
+        "x": -640,
+        "y": -10
+      },
+      "content": {
+        "fields": [
+          {
+            "field": "numberOfChildren",
+            "name": "Number of Children",
+            "id": 35,
+            "description": "The number of children active on a family unit.",
+            "dataType": "number-input",
+            "validationCriteria": "0",
+            "validationType": ">=",
+            "defaultValue": 4,
+            "childFields": []
+          },
+          {
+            "field": "familyComposition",
+            "name": "Family Composition",
+            "id": 16,
+            "description": "The types of family unit compositions. ",
+            "dataType": "text-input",
+            "validationCriteria": "single, couple",
+            "validationType": "[=text]",
+            "defaultValue": "single",
+            "childFields": []
+          },
+          {
+            "field": "familyUnitInPayForDecember",
+            "name": "Family Unit In Pay For December",
+            "id": 19,
+            "description": "Family Unit is in pay for the month of December.",
+            "dataType": "true-false",
+            "defaultValue": true,
+            "childFields": []
+          }
+        ]
+      }
+    },
+    {
+      "id": "86049028-7a4f-4b79-a1b1-025b98061ee0",
+      "name": "Winter Supplement Response",
+      "type": "outputNode",
+      "position": {
+        "x": 750,
+        "y": 125
+      },
+      "content": {
+        "fields": [
+          {
+            "field": "isEligible",
+            "name": "Is Eligible",
+            "id": 28,
+            "description": "General \"Is Eligible\" statement used in conjunction with supplement building to describe eligibility.",
+            "dataType": "true-false",
+            "defaultValue": true,
+
+            "childFields": []
+          },
+          {
+            "field": "baseAmount",
+            "name": "Base Amount",
+            "id": 1,
+            "description": "The base amount of a supplement. ",
+            "dataType": "number-input",
+            "validationCriteria": "0",
+            "validationType": ">=",
+            "defaultValue": 120,
+            "childFields": []
+          },
+          {
+            "field": "childrenAmount",
+            "name": "Children Amount",
+            "id": 6,
+            "description": "The amount for children for a given supplement.",
+            "dataType": "number-input",
+            "validationCriteria": "0",
+            "validationType": ">=",
+            "defaultValue": 80,
+            "childFields": []
+          },
+          {
+            "field": "supplementAmount",
+            "name": "Supplement Amount",
+            "id": 58,
+            "description": "General \"Supplement Amount\" field to define total supplement amount output for a specific supplement.",
+            "dataType": "number-input",
+            "validationCriteria": "0",
+            "validationType": ">=",
+            "defaultValue": 200,
+            "childFields": []
+          }
+        ]
+      }
+    },
+    {
+      "id": "d5e41add-1cb0-4e32-8667-ffd548e523bf",
+      "name": "Child Calculation",
+      "type": "decisionTableNode",
+      "content": {
+        "rules": [
+          {
+            "_id": "722b3945-02f5-4210-a9e4-b496d7d9438b",
+            "399837f9-5fd5-4936-8262-a47c36287cf7": "numberOfChildren*20",
+            "4513898e-c063-4670-a99a-804148934985": ""
+          }
+        ],
+        "inputs": [
+          {
+            "id": "4513898e-c063-4670-a99a-804148934985",
+            "name": "Number of Children",
+            "type": "expression",
+            "field": "numberOfChildren"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "399837f9-5fd5-4936-8262-a47c36287cf7",
+            "name": "Children Amount",
+            "type": "expression",
+            "field": "childrenAmount",
+            "defaultValue": "0"
+          }
+        ],
+        "hitPolicy": "first"
+      },
+      "position": {
+        "x": 120,
+        "y": 30
+      }
+    },
+    {
+      "id": "c3ab217c-22fa-4896-8f29-4a359e12f483",
+      "name": "Spouse Calculation",
+      "type": "decisionTableNode",
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [
+          {
+            "id": "3991b5b8-b68c-493d-a31b-226a0756ff28",
+            "name": "Family Composition",
+            "type": "expression",
+            "field": "familyComposition",
+            "defaultValue": "single"
+          },
+          {
+            "id": "33d4d4d1-a243-4d7f-8e0c-f73faaeb6cc1",
+            "field": "numberOfChildren",
+            "name": "Number of Children"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "c526b490-0906-4505-aff8-d161e8feed4b",
+            "name": "Base Amount",
+            "type": "expression",
+            "field": "baseAmount"
+          }
+        ],
+        "rules": [
+          {
+            "_id": "741c1d33-0606-4b95-a64b-b27bb9800820",
+            "3991b5b8-b68c-493d-a31b-226a0756ff28": "\"single\"",
+            "33d4d4d1-a243-4d7f-8e0c-f73faaeb6cc1": "$ > 0",
+            "c526b490-0906-4505-aff8-d161e8feed4b": "120"
+          },
+          {
+            "_id": "f3164738-59c2-4e3b-84d5-ceaf3e04aff2",
+            "3991b5b8-b68c-493d-a31b-226a0756ff28": "\"single\"",
+            "33d4d4d1-a243-4d7f-8e0c-f73faaeb6cc1": "",
+            "c526b490-0906-4505-aff8-d161e8feed4b": "60"
+          },
+          {
+            "_id": "1a7b357d-bbd8-481b-9c24-d91686c83e67",
+            "3991b5b8-b68c-493d-a31b-226a0756ff28": "\"couple\"",
+            "33d4d4d1-a243-4d7f-8e0c-f73faaeb6cc1": "",
+            "c526b490-0906-4505-aff8-d161e8feed4b": "120"
+          }
+        ]
+      },
+      "position": {
+        "x": 120,
+        "y": -80
+      }
+    },
+    {
+      "id": "84cf05d5-9ef3-4e83-bb7c-2b686e6b7815",
+      "name": "Total Supplement",
+      "type": "decisionTableNode",
+      "content": {
+        "rules": [
+          {
+            "_id": "aa135592-8426-42ae-8d23-4512caeea78e",
+            "16683437-061d-4caf-804f-aefeeddc9b32": "baseAmount+childrenAmount",
+            "6abe1cb3-a3da-4770-abdc-25de26f96a88": "",
+            "dc3e0c07-45e0-4220-ba8e-f3d654be8f0a": ""
+          }
+        ],
+        "inputs": [
+          {
+            "id": "6abe1cb3-a3da-4770-abdc-25de26f96a88",
+            "name": "Base Amount",
+            "type": "expression",
+            "field": "baseAmount",
+            "defaultValue": "0"
+          },
+          {
+            "id": "dc3e0c07-45e0-4220-ba8e-f3d654be8f0a",
+            "name": "Children Amount",
+            "type": "expression",
+            "field": "childrenAmount",
+            "defaultValue": "0"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "16683437-061d-4caf-804f-aefeeddc9b32",
+            "name": "Supplement Amount",
+            "type": "expression",
+            "field": "supplementAmount"
+          }
+        ],
+        "hitPolicy": "first"
+      },
+      "position": {
+        "x": 550,
+        "y": -120
+      }
+    },
+    {
+      "id": "bd7103da-9a6e-4fbd-ba14-12008e3cd61c",
+      "name": "Should Calculate Supplement",
+      "type": "switchNode",
+      "content": {
+        "statements": [
+          {
+            "id": "38203cc4-5089-4ed7-b19c-58a99b65e545",
+            "condition": "isEligible"
+          }
+        ]
+      },
+      "position": {
+        "x": -225,
+        "y": -80
+      }
+    },
+    {
+      "id": "7b088ca1-2314-45ec-835c-c38e66f7cb5c",
+      "name": "IsEligible",
+      "type": "expressionNode",
+      "content": {
+        "expressions": [
+          {
+            "id": "3c63ac7c-49a8-4e3f-b23c-53e78666b29a",
+            "key": "isEligible",
+            "value": "familyUnitInPayForDecember"
+          }
+        ]
+      },
+      "position": {
+        "x": -335,
+        "y": 160
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "39711638-645a-4f35-b85d-3b619f47cc8e",
+      "type": "edge",
+      "sourceId": "bd7103da-9a6e-4fbd-ba14-12008e3cd61c",
+      "targetId": "d5e41add-1cb0-4e32-8667-ffd548e523bf",
+      "sourceHandle": "38203cc4-5089-4ed7-b19c-58a99b65e545"
+    },
+    {
+      "id": "363f09ea-7a0f-4b9c-bf2c-aa00ef6925e0",
+      "type": "edge",
+      "sourceId": "bd7103da-9a6e-4fbd-ba14-12008e3cd61c",
+      "targetId": "c3ab217c-22fa-4896-8f29-4a359e12f483",
+      "sourceHandle": "38203cc4-5089-4ed7-b19c-58a99b65e545"
+    },
+    {
+      "id": "d5c6c7df-dc16-47d4-b84d-e005893ee2d1",
+      "type": "edge",
+      "sourceId": "8ac97728-c53d-441b-8c4f-cbce96bbbfb1",
+      "targetId": "7b088ca1-2314-45ec-835c-c38e66f7cb5c"
+    },
+    {
+      "id": "19ebf821-284b-4b01-99cc-5e51837d2408",
+      "type": "edge",
+      "sourceId": "7b088ca1-2314-45ec-835c-c38e66f7cb5c",
+      "targetId": "bd7103da-9a6e-4fbd-ba14-12008e3cd61c"
+    },
+    {
+      "id": "aed0501a-8138-4cfa-b7f3-7b8eee7807c9",
+      "type": "edge",
+      "sourceId": "7b088ca1-2314-45ec-835c-c38e66f7cb5c",
+      "targetId": "86049028-7a4f-4b79-a1b1-025b98061ee0"
+    },
+    {
+      "id": "533fcf7b-c45d-45fd-b1e9-3099217d9ded",
+      "type": "edge",
+      "sourceId": "8ac97728-c53d-441b-8c4f-cbce96bbbfb1",
+      "targetId": "bd7103da-9a6e-4fbd-ba14-12008e3cd61c"
+    },
+    {
+      "id": "6fa54de0-abe4-4581-9ffb-54bbc1faa0f9",
+      "type": "edge",
+      "sourceId": "c3ab217c-22fa-4896-8f29-4a359e12f483",
+      "targetId": "86049028-7a4f-4b79-a1b1-025b98061ee0"
+    },
+    {
+      "id": "4969d7e2-7417-4185-922a-a128ab998f20",
+      "type": "edge",
+      "sourceId": "d5e41add-1cb0-4e32-8667-ffd548e523bf",
+      "targetId": "86049028-7a4f-4b79-a1b1-025b98061ee0"
+    },
+    {
+      "id": "7e990235-16d1-4220-9621-baf08c49e3b2",
+      "type": "edge",
+      "sourceId": "c3ab217c-22fa-4896-8f29-4a359e12f483",
+      "targetId": "84cf05d5-9ef3-4e83-bb7c-2b686e6b7815"
+    },
+    {
+      "id": "793c31a0-6a07-4d94-b79b-bad5fd4e6a1c",
+      "type": "edge",
+      "sourceId": "d5e41add-1cb0-4e32-8667-ffd548e523bf",
+      "targetId": "84cf05d5-9ef3-4e83-bb7c-2b686e6b7815"
+    },
+    {
+      "id": "8b1fc9c9-65ab-4024-8994-832f0bb32201",
+      "type": "edge",
+      "sourceId": "84cf05d5-9ef3-4e83-bb7c-2b686e6b7815",
+      "targetId": "86049028-7a4f-4b79-a1b1-025b98061ee0"
+    }
+  ]
+}

--- a/src/examples/klammRule.example.ts
+++ b/src/examples/klammRule.example.ts
@@ -1,0 +1,85 @@
+export const klammResponseExamples = {
+  breFields: {
+    data: [
+      {
+        id: 1,
+        name: 'isEligible',
+        label: 'Is Eligible',
+        data_type: {
+          id: 5,
+          name: 'true-false',
+          short_description: 'True/False',
+          bre_value_type: {
+            id: 7,
+            name: 'Boolean',
+          },
+        },
+      },
+    ],
+  },
+  breRules: [
+    {
+      id: 17,
+      name: 'wintersupplement',
+      label: 'Winter Supplement',
+      description: null,
+      internal_description: null,
+      rule_inputs: [
+        {
+          id: 19,
+          name: 'familyUnitInPayForDecember',
+          label: 'Family Unit In Pay For December',
+          help_text: null,
+          data_type_id: 5,
+          description: 'Family Unit in receipt of assistance for the month of december.',
+          data_validation_id: null,
+          pivot: {
+            bre_rule_id: 17,
+            bre_field_id: 19,
+            created_at: '2024-10-29T16:07:35.000000Z',
+            updated_at: '2024-10-29T16:07:35.000000Z',
+          },
+        },
+        {
+          id: 16,
+          name: 'familyComposition',
+          label: 'Family Composition',
+          help_text: null,
+          data_type_id: 1,
+          description: null,
+          created_at: '2024-08-30T22:56:49.000000Z',
+          updated_at: '2024-09-18T17:38:10.000000Z',
+          data_validation_id: 20,
+          pivot: {
+            bre_rule_id: 17,
+            bre_field_id: 16,
+            created_at: '2024-10-22T21:57:57.000000Z',
+            updated_at: '2024-10-22T21:57:57.000000Z',
+          },
+        },
+      ],
+      rule_outputs: [
+        {
+          id: 6,
+          name: 'childrenAmount',
+          label: 'Children Amount',
+          help_text: null,
+          data_type_id: 10,
+          description: null,
+          created_at: '2024-08-30T22:56:49.000000Z',
+          updated_at: '2024-08-30T22:56:49.000000Z',
+          data_validation_id: null,
+          pivot: {
+            bre_rule_id: 17,
+            bre_field_id: 6,
+            created_at: '2024-10-22T21:57:57.000000Z',
+            updated_at: '2024-10-22T21:57:57.000000Z',
+          },
+        },
+      ],
+      parent_rules: [],
+      child_rules: [],
+      icmcdw_fields: [],
+    },
+  ],
+};

--- a/src/examples/rule.example.ts
+++ b/src/examples/rule.example.ts
@@ -1,0 +1,48 @@
+import * as exampleRuleContent from './exampleRule.json';
+
+export const ruleExample = {
+  _id: '12345678abcdefg',
+  name: 'wintersupplement',
+  filepath: 'general-supplements/wintersupplement.json',
+  isPublished: true,
+  __v: 0,
+  ruleDraft: '987654321abcdefgh',
+  reviewBranch: null,
+  title: 'Winter Supplement',
+};
+
+export const ruleExample2 = {
+  _id: '12345678abcdefg2',
+  name: 'natalsupplement',
+  title: 'Natal Supplement',
+  filepath: 'health-supplements/natalsupplement.json',
+  ruleDraft: 'abcdefg12345678',
+  __v: 0,
+};
+
+export const ruleList = [
+  { text: 'general-supplements', value: 'general-supplements' },
+  { text: 'health-supplements', value: 'health-supplements' },
+];
+
+export const ruleInputMetadata = exampleRuleContent.nodes[0].content.fields;
+
+export const ruleOutputMetadata = exampleRuleContent.nodes[1].content.fields;
+
+export const ruleInputs = ruleInputMetadata.reduce(
+  (acc, meta) => ({
+    ...acc,
+    [meta.field]: meta.defaultValue,
+  }),
+  {},
+);
+
+export const ruleOutputs = ruleOutputMetadata.reduce(
+  (acc, meta) => ({
+    ...acc,
+    [meta.field]: meta.defaultValue,
+  }),
+  {},
+);
+
+export const ruleContentExample = exampleRuleContent;

--- a/src/examples/scenario.example.ts
+++ b/src/examples/scenario.example.ts
@@ -1,0 +1,62 @@
+import { ruleExample } from './rule.example';
+
+export const variableExamples = [
+  {
+    name: 'numberOfChildren',
+    value: 4,
+    type: 'number',
+    _id: '673fb8ffba3406edda2fdc2d',
+  },
+  {
+    name: 'familyComposition',
+    value: 'single',
+    type: 'string',
+    _id: '673fb8ffba3406edda2fdc2e',
+  },
+  {
+    name: 'familyUnitInPayForDecember',
+    value: true,
+    type: 'boolean',
+    _id: '673fb8ffba3406edda2fdc2f',
+  },
+];
+
+export const expectedResultsExample = [
+  {
+    name: 'baseAmount',
+    value: 120,
+    type: 'number',
+    _id: '67899ac720bf8b927ca569af',
+  },
+  {
+    name: 'childrenAmount',
+    value: 80,
+    type: 'number',
+    _id: '67899ac720bf8b927ca569b0',
+  },
+  {
+    name: 'isEligible',
+    value: true,
+    type: 'boolean',
+    _id: '67899ac720bf8b927ca569b1',
+  },
+  {
+    name: 'supplementAmount',
+    value: 200,
+    type: 'number',
+    _id: '67899ac720bf8b927ca569b2',
+  },
+];
+
+export const scenarioExample = {
+  _id: '673e6ae3ba3406edda2fc25e',
+  title: 'Testing Winter Supplement',
+  ruleID: ruleExample._id,
+  variables: variableExamples,
+  expectedResults: expectedResultsExample,
+  filepath: ruleExample.filepath,
+  __v: 1,
+};
+
+export const scenarioCSVExample = `Scenario,Results Match Expected (Pass/Fail),Input: familyComposition,Input: familyUnitInPayForDecember,Input: numberOfChildren,Expected Result: baseAmount,Expected Result: childrenAmount,Expected Result: isEligible,Expected Result: supplementAmount,Result: baseAmount,Result: childrenAmount,Result: isEligible,Result: supplementAmount,Error?
+Testing Winter Supplement,Pass,single,true,4,120,80,true,200,120,80,true,200,`;

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,22 +1,67 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
-jest.mock('@nestjs/core', () => {
+const mockApp = {
+  enableCors: jest.fn(),
+  listen: jest.fn(),
+  getHttpAdapter: jest.fn().mockReturnValue({
+    getInstance: jest.fn(),
+  }),
+};
+
+jest.mock('@nestjs/core', () => ({
+  NestFactory: {
+    create: jest.fn().mockImplementation(() => Promise.resolve(mockApp)),
+  },
+}));
+
+jest.mock('nest-winston', () => ({
+  WinstonModule: {
+    createLogger: jest.fn(),
+  },
+}));
+
+jest.mock('@nestjs/swagger', () => {
+  const originalModule = jest.requireActual('@nestjs/swagger');
   return {
-    NestFactory: {
-      create: jest.fn().mockImplementation(() => {
-        return {
-          enableCors: jest.fn(),
-          listen: jest.fn(),
-        };
-      }),
+    ...originalModule,
+    SwaggerModule: {
+      createDocument: jest.fn(),
+      setup: jest.fn(),
     },
+    ApiBearerAuth: jest.fn(() => () => {}),
+    ApiTags: jest.fn(() => () => {}),
+    ApiOperation: jest.fn(() => () => {}),
+    ApiResponse: jest.fn(() => () => {}),
+    DocumentBuilder: jest.fn(() => ({
+      setTitle: jest.fn().mockReturnThis(),
+      setDescription: jest.fn().mockReturnThis(),
+      setVersion: jest.fn().mockReturnThis(),
+      addTag: jest.fn().mockReturnThis(),
+      build: jest.fn(),
+    })),
   };
 });
 
 describe('main.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should bootstrap the application', async () => {
     await require('./main');
-    expect(NestFactory.create).toHaveBeenCalledWith(AppModule, expect.any(Object));
+
+    expect(NestFactory.create).toHaveBeenCalledWith(
+      AppModule,
+      expect.objectContaining({
+        logger: undefined,
+      }),
+    );
+
+    expect(mockApp.enableCors).toHaveBeenCalledWith({
+      origin: process.env.FRONTEND_URI,
+    });
+
+    expect(mockApp.listen).toHaveBeenCalledWith(process.env.PORT || 3000);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as winston from 'winston';
 import { WinstonModule } from 'nest-winston';
 import { AppModule } from './app.module';
 import { winstonConfig } from './winston-config.service';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   // Setup app with logging
@@ -16,6 +17,25 @@ async function bootstrap() {
   // Enable CORS for frontend
   app.enableCors({
     origin: process.env.FRONTEND_URI,
+  });
+  // Setup Swagger
+  const config = new DocumentBuilder()
+    .setTitle('BRM App API')
+    .setDescription('The BRM App API provides endpoints for managing rules and decisions.')
+    .setVersion('1.0')
+    .addTag('nest')
+    .build();
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+
+  SwaggerModule.setup('api', app, documentFactory, {
+    swaggerOptions: {
+      // Display only GET and HEAD endpoints for 'Try it Out' function in Swagger UI until additional security is implemented
+      supportedSubmitMethods: [
+        'get',
+        'head',
+        // 'post', 'put', 'patch', 'delete'
+      ],
+    },
   });
   // Start the app on the specified port
   const port = process.env.PORT || 3000;

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,4 +1,4 @@
-import * as csvParser from 'csv-parser';
+import csvParser from 'csv-parser';
 import { formatValue, filterKeys } from './helpers';
 import { Variable } from '../api/scenarioData/scenarioData.schema';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
- Add swagger API generation for all endpoints.
- This includes the creation of a new 'examples' folder that holds current examples of a winter supplement rule, including a test scenario, a version of the rule from klamm, the rule response in the BRM App, and the resulting decision.
- This version currently displays only GET and HEAD endpoints for the 'Try it Out' function in Swagger UI, with 'post', 'put', 'patch', and 'delete' methods restricted to view only.
- No significant material changes were made to how the api functions, as this was primarily aimed at introducing the API documentation generation through swagger.
- No fail responses have been documented, only 'happy paths'.