### PR TITLE
Feature/rule version support

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,10 +43,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # This is the branch name we want to use of the rules repo branch
-          # We want it to be the same as the branch we are building so they stay in sync
-          build-args: |
-            RULES_REPO_BRANCH=${{ env.BRANCH_NAME }}
 
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/csv-rule-tests.yml
+++ b/.github/workflows/csv-rule-tests.yml
@@ -1,4 +1,3 @@
-
 name: CSV Rule Tests
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Rules folder
+rules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Install the app dependencies in a full Node docker image
 FROM registry.access.redhat.com/ubi9/nodejs-20:latest
 
-# Set the environment variables
-ARG RULES_REPO_BRANCH
-ENV RULES_REPO_BRANCH=${RULES_REPO_BRANCH}
-
 # Set the working directory
 WORKDIR /opt/app-root/src
 
@@ -18,8 +14,15 @@ RUN npm ci
 # Copy the application code
 COPY . ./
 
-# Clone the rules repository
-RUN git clone -b ${RULES_REPO_BRANCH} https://github.com/bcgov/brms-rules.git brms-rules
+# Clone the production rules repository into rules/prod
+RUN git clone -b main https://github.com/bcgov/brms-rules.git ./tmp-brm-rules && \
+    mv ./tmp-brm-rules/rules/* rules/prod && \
+    rm -rf /tmp/brms-rules
+
+# Clone the dev rules repository into rules/dev
+RUN git clone -b dev https://github.com/bcgov/brms-rules.git ./tmp-brm-rules && \
+    mv ./tmp-brm-rules/rules/* rules/dev && \
+    rm -rf /tmp/brms-rules
 
 # Start the application
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ To set up MongoDB and populate it with initial data, follow these steps:
 
 ### Including Rules from the Rules Repository
 
-To get access to rules locally on your machine simply clone the repo at https://github.com/bcgov/brms-rules into your project. This project is set to grab rules from `brms-rules/rules`, which is the default location of rules if that project is cloned into this one.
+To get access to rules locally on your machine simply clone the repo at https://github.com/bcgov/brms-rules and ensure the rules are placed at the brm-backend/rules/prod location (for main branch/production rules) or brm-backend/rules/dev location (for dev branch/dev rules).
 
 ```bash
 git clone https://github.com/bcgov/brms-rules.git
+```
+
+```bash
+cp -r brms-rules/rules/* brm-backend/rules/prod
 ```
 
 ### Setting Environment Variables

--- a/src/api/decisions/decisions.controller.spec.ts
+++ b/src/api/decisions/decisions.controller.spec.ts
@@ -34,7 +34,12 @@ describe('DecisionsController', () => {
       trace: false,
     };
     await controller.evaluateDecisionByContent(dto);
-    expect(service.runDecisionByContent).toHaveBeenCalledWith(dto.ruleContent, dto.context, { trace: dto.trace });
+    expect(service.runDecisionByContent).toHaveBeenCalledWith(
+      dto.ruleContent,
+      dto.context,
+      { trace: dto.trace },
+      undefined,
+    );
   });
 
   it('should throw an error when runDecision fails', async () => {
@@ -65,7 +70,7 @@ describe('DecisionsController', () => {
     const dto: EvaluateDecisionDto = { context: { value: 'context' }, trace: false };
     const ruleFileName = 'rule';
     await controller.evaluateDecisionByFile(ruleFileName, dto);
-    expect(service.runDecisionByFile).toHaveBeenCalledWith(ruleFileName, dto.context, { trace: dto.trace });
+    expect(service.runDecisionByFile).toHaveBeenCalledWith(ruleFileName, dto.context, { trace: dto.trace }, undefined);
   });
 
   it('should throw an error when runDecisionByFile fails', async () => {

--- a/src/api/decisions/decisions.controller.ts
+++ b/src/api/decisions/decisions.controller.ts
@@ -21,9 +21,9 @@ export class DecisionsController {
     description: 'Decision evaluated successfully',
     schema: { example: decisionExample },
   })
-  async evaluateDecisionByContent(@Body() { ruleContent, context, trace, isDev }: EvaluateDecisionWithContentDto) {
+  async evaluateDecisionByContent(@Body() { ruleContent, context, trace }: EvaluateDecisionWithContentDto) {
     try {
-      return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace }, isDev);
+      return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace });
     } catch (error) {
       if (error instanceof ValidationError) {
         throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
@@ -52,10 +52,10 @@ export class DecisionsController {
   })
   async evaluateDecisionByFile(
     @Query('ruleFileName') ruleFileName: string,
-    @Body() { context, trace, isDev }: EvaluateDecisionDto,
+    @Body() { context, trace }: EvaluateDecisionDto,
   ) {
     try {
-      return await this.decisionsService.runDecisionByFile(ruleFileName, context, { trace }, isDev);
+      return await this.decisionsService.runDecisionByFile(ruleFileName, context, { trace });
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/api/decisions/decisions.controller.ts
+++ b/src/api/decisions/decisions.controller.ts
@@ -21,9 +21,9 @@ export class DecisionsController {
     description: 'Decision evaluated successfully',
     schema: { example: decisionExample },
   })
-  async evaluateDecisionByContent(@Body() { ruleContent, context, trace }: EvaluateDecisionWithContentDto) {
+  async evaluateDecisionByContent(@Body() { ruleContent, context, trace, isDev }: EvaluateDecisionWithContentDto) {
     try {
-      return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace });
+      return await this.decisionsService.runDecisionByContent(ruleContent, context, { trace }, isDev);
     } catch (error) {
       if (error instanceof ValidationError) {
         throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
@@ -52,10 +52,10 @@ export class DecisionsController {
   })
   async evaluateDecisionByFile(
     @Query('ruleFileName') ruleFileName: string,
-    @Body() { context, trace }: EvaluateDecisionDto,
+    @Body() { context, trace, isDev }: EvaluateDecisionDto,
   ) {
     try {
-      return await this.decisionsService.runDecisionByFile(ruleFileName, context, { trace });
+      return await this.decisionsService.runDecisionByFile(ruleFileName, context, { trace }, isDev);
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -1,13 +1,14 @@
-import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
 import { ZenEngine, ZenDecision, ZenEvaluateOptions } from '@gorules/zen-engine';
 import { DecisionsService } from './decisions.service';
 import { ValidationService } from './validations/validations.service';
-import { readFileSafely, FileNotFoundError } from '../../utils/readFile';
+import { FileNotFoundError } from '../../utils/readFile';
 import { RuleContent } from '../ruleMapping/ruleMapping.interface';
 import { ValidationError } from './validations/validation.error';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { mockRuleDataServiceProviders } from '../ruleData/ruleData.service.spec';
+import { RuleDataService } from '../ruleData/ruleData.service';
 
 jest.mock('../../utils/readFile', () => ({
   readFileSafely: jest.fn(),
@@ -16,6 +17,7 @@ jest.mock('../../utils/readFile', () => ({
 
 describe('DecisionsService', () => {
   let service: DecisionsService;
+  let ruleDataService: RuleDataService;
   let validationService: ValidationService;
   let mockEngine: Partial<ZenEngine>;
   let mockDecision: Partial<ZenDecision>;
@@ -30,7 +32,7 @@ describe('DecisionsService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        ConfigService,
+        ...mockRuleDataServiceProviders,
         DecisionsService,
         ValidationService,
         { provide: ZenEngine, useValue: mockEngine },
@@ -39,9 +41,11 @@ describe('DecisionsService', () => {
     }).compile();
 
     service = module.get<DecisionsService>(DecisionsService);
+    ruleDataService = module.get<RuleDataService>(RuleDataService);
     validationService = module.get<ValidationService>(ValidationService);
     service.engine = mockEngine as ZenEngine;
     jest.spyOn(validationService, 'validateInputs').mockImplementation(() => {});
+    jest.spyOn(ruleDataService, 'getContentForRuleFromFilepath').mockResolvedValue(Buffer.from(''));
   });
 
   describe('runDecision', () => {
@@ -71,13 +75,15 @@ describe('DecisionsService', () => {
       const options: ZenEvaluateOptions = { trace: false };
       const content = { rule: 'rule' };
 
-      (readFileSafely as jest.Mock).mockResolvedValue(Buffer.from(JSON.stringify(content)));
+      (ruleDataService.getContentForRuleFromFilepath as jest.Mock).mockResolvedValue(
+        Buffer.from(JSON.stringify(content)),
+      );
 
       // Call runDecision with null/undefined ruleContent
       await service.runDecision(null, ruleFileName, context, options);
 
       // Verify that readFileSafely was called, indicating fallback to runDecisionByFile
-      expect(readFileSafely).toHaveBeenCalledWith(service.rulesDirectory, ruleFileName);
+      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName, false);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });
@@ -133,9 +139,11 @@ describe('DecisionsService', () => {
       const context = {};
       const options: ZenEvaluateOptions = { trace: false };
       const content = { rule: 'rule' };
-      (readFileSafely as jest.Mock).mockResolvedValue(Buffer.from(JSON.stringify(content)));
+      (ruleDataService.getContentForRuleFromFilepath as jest.Mock).mockResolvedValue(
+        Buffer.from(JSON.stringify(content)),
+      );
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(readFileSafely).toHaveBeenCalledWith(service.rulesDirectory, ruleFileName);
+      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName, false);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });
@@ -144,7 +152,7 @@ describe('DecisionsService', () => {
       const ruleFileName = 'rule';
       const context = {};
       const options: ZenEvaluateOptions = { trace: false };
-      (readFileSafely as jest.Mock).mockRejectedValue(new Error('Error'));
+      (ruleDataService.getContentForRuleFromFilepath as jest.Mock).mockRejectedValue(new Error('Error'));
       await expect(service.runDecisionByFile(ruleFileName, context, options)).rejects.toThrow(
         'Failed to run decision: Error',
       );
@@ -155,7 +163,9 @@ describe('DecisionsService', () => {
     const context = {};
     const options: ZenEvaluateOptions = { trace: false };
 
-    (readFileSafely as jest.Mock).mockRejectedValue(new FileNotFoundError('File not found'));
+    (ruleDataService.getContentForRuleFromFilepath as jest.Mock).mockRejectedValue(
+      new FileNotFoundError('File not found'),
+    );
 
     await expect(service.runDecisionByFile(ruleFileName, context, options)).rejects.toThrow(
       new HttpException('Rule not found', HttpStatus.NOT_FOUND),

--- a/src/api/decisions/decisions.service.spec.ts
+++ b/src/api/decisions/decisions.service.spec.ts
@@ -83,7 +83,7 @@ describe('DecisionsService', () => {
       await service.runDecision(null, ruleFileName, context, options);
 
       // Verify that readFileSafely was called, indicating fallback to runDecisionByFile
-      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName, false);
+      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });
@@ -143,7 +143,7 @@ describe('DecisionsService', () => {
         Buffer.from(JSON.stringify(content)),
       );
       await service.runDecisionByFile(ruleFileName, context, options);
-      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName, false);
+      expect(ruleDataService.getContentForRuleFromFilepath).toHaveBeenCalledWith(ruleFileName);
       expect(mockEngine.createDecision).toHaveBeenCalledWith(content);
       expect(mockDecision.evaluate).toHaveBeenCalledWith(context, options);
     });

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -25,7 +25,12 @@ export class DecisionsService {
     this.devEngine = new ZenEngine({ loader: loader(false) });
   }
 
-  async runDecisionByContent(ruleContent: RuleContent, context: object, options: ZenEvaluateOptions, isDev: boolean) {
+  async runDecisionByContent(
+    ruleContent: RuleContent,
+    context: object,
+    options: ZenEvaluateOptions,
+    isDev: boolean = false,
+  ) {
     const validator = new ValidationService();
     const ruleInputs = ruleContent?.nodes?.filter((node) => node.type === 'inputNode')[0]?.content;
     try {
@@ -43,9 +48,9 @@ export class DecisionsService {
     }
   }
 
-  async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions, isDev: boolean) {
+  async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions, isDev: boolean = false) {
     try {
-      const decisionFile = this.ruleDataService.getContentForRuleFromFilepath(ruleFileName, isDev);
+      const decisionFile = await this.ruleDataService.getContentForRuleFromFilepath(ruleFileName, isDev);
       const content: RuleContent = JSON.parse(decisionFile.toString()); // Convert file buffer to rulecontent
       return this.runDecisionByContent(content, context, options, isDev);
     } catch (error) {

--- a/src/api/decisions/decisions.service.ts
+++ b/src/api/decisions/decisions.service.ts
@@ -1,31 +1,37 @@
 import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ZenEngine, ZenEvaluateOptions } from '@gorules/zen-engine';
-import { ConfigService } from '@nestjs/config';
 import { RuleContent } from '../ruleMapping/ruleMapping.interface';
-import { readFileSafely, FileNotFoundError } from '../../utils/readFile';
+import { FileNotFoundError } from '../../utils/readFile';
 import { ValidationService } from './validations/validations.service';
 import { ValidationError } from './validations/validation.error';
+import { RuleDataService } from '../ruleData/ruleData.service';
 
 @Injectable()
 export class DecisionsService {
   engine: ZenEngine;
-  rulesDirectory: string;
+  devEngine: ZenEngine;
 
   constructor(
-    private configService: ConfigService,
+    private ruleDataService: RuleDataService,
     private readonly logger: Logger,
   ) {
-    this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
-    const loader = async (key: string) => readFileSafely(this.rulesDirectory, key);
-    this.engine = new ZenEngine({ loader });
+    // Create a loader function for linked rules
+    // This is where we will load different versions of the rules if necessary
+    const loader = (isDev: boolean) => async (key: string) => {
+      return this.ruleDataService.getContentForRuleFromFilepath(key, isDev);
+    };
+    // Create the engines for running the rules (one for dev and one for prod)
+    this.engine = new ZenEngine({ loader: loader(true) });
+    this.devEngine = new ZenEngine({ loader: loader(false) });
   }
 
-  async runDecisionByContent(ruleContent: RuleContent, context: object, options: ZenEvaluateOptions) {
+  async runDecisionByContent(ruleContent: RuleContent, context: object, options: ZenEvaluateOptions, isDev: boolean) {
     const validator = new ValidationService();
     const ruleInputs = ruleContent?.nodes?.filter((node) => node.type === 'inputNode')[0]?.content;
     try {
       validator.validateInputs(ruleInputs, context);
-      const decision = this.engine.createDecision(ruleContent);
+      const engine = isDev ? this.devEngine : this.engine;
+      const decision = engine.createDecision(ruleContent);
       return await decision.evaluate(context, options);
     } catch (error) {
       if (error instanceof ValidationError) {
@@ -37,11 +43,11 @@ export class DecisionsService {
     }
   }
 
-  async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions) {
+  async runDecisionByFile(ruleFileName: string, context: object, options: ZenEvaluateOptions, isDev: boolean) {
     try {
-      const decisionFile = await readFileSafely(this.rulesDirectory, ruleFileName);
+      const decisionFile = this.ruleDataService.getContentForRuleFromFilepath(ruleFileName, isDev);
       const content: RuleContent = JSON.parse(decisionFile.toString()); // Convert file buffer to rulecontent
-      return this.runDecisionByContent(content, context, options);
+      return this.runDecisionByContent(content, context, options, isDev);
     } catch (error) {
       if (error instanceof FileNotFoundError) {
         throw new HttpException('Rule not found', HttpStatus.NOT_FOUND);
@@ -52,11 +58,17 @@ export class DecisionsService {
   }
 
   /** Run the decision by content if it exists, otherwise run by filename */
-  async runDecision(ruleContent: RuleContent, ruleFileName: string, context: object, options: ZenEvaluateOptions) {
+  async runDecision(
+    ruleContent: RuleContent,
+    ruleFileName: string,
+    context: object,
+    options: ZenEvaluateOptions,
+    isDev: boolean = false,
+  ) {
     if (ruleContent) {
-      return await this.runDecisionByContent(ruleContent, context, options);
+      return await this.runDecisionByContent(ruleContent, context, options, isDev);
     } else {
-      return await this.runDecisionByFile(ruleFileName, context, options);
+      return await this.runDecisionByFile(ruleFileName, context, options, isDev);
     }
   }
 }

--- a/src/api/decisions/dto/evaluate-decision.dto.ts
+++ b/src/api/decisions/dto/evaluate-decision.dto.ts
@@ -18,13 +18,6 @@ export class EvaluateDecisionDto {
   })
   @IsBoolean()
   trace: boolean;
-
-  @ApiProperty({
-    example: false,
-    description: '',
-  })
-  @IsBoolean()
-  isDev?: boolean;
 }
 
 @ApiSchema({ description: 'DTO for evaluating a decision with rule content' })

--- a/src/api/decisions/dto/evaluate-decision.dto.ts
+++ b/src/api/decisions/dto/evaluate-decision.dto.ts
@@ -18,6 +18,13 @@ export class EvaluateDecisionDto {
   })
   @IsBoolean()
   trace: boolean;
+
+  @ApiProperty({
+    example: false,
+    description: '',
+  })
+  @IsBoolean()
+  isDev: boolean;
 }
 
 @ApiSchema({ description: 'DTO for evaluating a decision with rule content' })

--- a/src/api/decisions/dto/evaluate-decision.dto.ts
+++ b/src/api/decisions/dto/evaluate-decision.dto.ts
@@ -24,7 +24,7 @@ export class EvaluateDecisionDto {
     description: '',
   })
   @IsBoolean()
-  isDev: boolean;
+  isDev?: boolean;
 }
 
 @ApiSchema({ description: 'DTO for evaluating a decision with rule content' })

--- a/src/api/documents/documents.controller.spec.ts
+++ b/src/api/documents/documents.controller.spec.ts
@@ -55,7 +55,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockResolvedValueOnce(mockFileContent);
 
-      await documentsController.getRuleFile(ruleFileName, res);
+      await documentsController.getRuleFile(ruleFileName, 'false', res);
 
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
       expect(res.setHeader).toHaveBeenCalledWith('Content-Disposition', `attachment; filename=${ruleFileName}`);
@@ -72,7 +72,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockRejectedValueOnce(mockError);
 
-      await expect(documentsController.getRuleFile(ruleFileName, res)).rejects.toThrow(
+      await expect(documentsController.getRuleFile(ruleFileName, 'false', res)).rejects.toThrow(
         new HttpException(mockError.message, HttpStatus.INTERNAL_SERVER_ERROR),
       );
     });
@@ -89,7 +89,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockResolvedValueOnce(mockFileContent);
 
-      await expect(documentsController.getRuleFile(ruleFileName, res)).rejects.toThrow(
+      await expect(documentsController.getRuleFile(ruleFileName, 'false', res)).rejects.toThrow(
         new HttpException('Failed to send response', HttpStatus.INTERNAL_SERVER_ERROR),
       );
 

--- a/src/api/documents/documents.controller.spec.ts
+++ b/src/api/documents/documents.controller.spec.ts
@@ -55,7 +55,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockResolvedValueOnce(mockFileContent);
 
-      await documentsController.getRuleFile(ruleFileName, 'false', res);
+      await documentsController.getRuleFile(ruleFileName, res);
 
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
       expect(res.setHeader).toHaveBeenCalledWith('Content-Disposition', `attachment; filename=${ruleFileName}`);
@@ -72,7 +72,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockRejectedValueOnce(mockError);
 
-      await expect(documentsController.getRuleFile(ruleFileName, 'false', res)).rejects.toThrow(
+      await expect(documentsController.getRuleFile(ruleFileName, res)).rejects.toThrow(
         new HttpException(mockError.message, HttpStatus.INTERNAL_SERVER_ERROR),
       );
     });
@@ -89,7 +89,7 @@ describe('DocumentsController', () => {
 
       jest.spyOn(documentsService, 'getFileContent').mockResolvedValueOnce(mockFileContent);
 
-      await expect(documentsController.getRuleFile(ruleFileName, 'false', res)).rejects.toThrow(
+      await expect(documentsController.getRuleFile(ruleFileName, res)).rejects.toThrow(
         new HttpException('Failed to send response', HttpStatus.INTERNAL_SERVER_ERROR),
       );
 

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -29,11 +29,6 @@ export class DocumentsController {
     example: ruleExample.filepath,
     required: true,
   })
-  @ApiQuery({
-    name: 'isDevRule',
-    description: '',
-    example: false,
-  })
   @ApiResponse({
     status: 200,
     description: 'Rule file retrieved successfully',
@@ -41,12 +36,8 @@ export class DocumentsController {
       example: ruleContentExample,
     },
   })
-  async getRuleFile(
-    @Query('ruleFileName') ruleFileName: string,
-    @Query('isDevRule') isDevRule: string,
-    @Res() res: Response,
-  ) {
-    const fileContent = await this.documentsService.getFileContent(ruleFileName, isDevRule === 'true');
+  async getRuleFile(@Query('ruleFileName') ruleFileName: string, @Res() res: Response) {
+    const fileContent = await this.documentsService.getFileContent(ruleFileName);
 
     try {
       res.setHeader('Content-Type', 'application/json');

--- a/src/api/documents/documents.controller.ts
+++ b/src/api/documents/documents.controller.ts
@@ -29,6 +29,11 @@ export class DocumentsController {
     example: ruleExample.filepath,
     required: true,
   })
+  @ApiQuery({
+    name: 'isDevRule',
+    description: '',
+    example: false,
+  })
   @ApiResponse({
     status: 200,
     description: 'Rule file retrieved successfully',
@@ -36,8 +41,12 @@ export class DocumentsController {
       example: ruleContentExample,
     },
   })
-  async getRuleFile(@Query('ruleFileName') ruleFileName: string, @Res() res: Response) {
-    const fileContent = await this.documentsService.getFileContent(ruleFileName);
+  async getRuleFile(
+    @Query('ruleFileName') ruleFileName: string,
+    @Query('isDevRule') isDevRule: string,
+    @Res() res: Response,
+  ) {
+    const fileContent = await this.documentsService.getFileContent(ruleFileName, isDevRule === 'true');
 
     try {
       res.setHeader('Content-Type', 'application/json');

--- a/src/api/documents/documents.service.ts
+++ b/src/api/documents/documents.service.ts
@@ -7,9 +7,11 @@ import { readFileSafely, FileNotFoundError } from '../../utils/readFile';
 @Injectable()
 export class DocumentsService {
   rulesDirectory: string;
+  devRulesDirectory: string;
 
   constructor(private configService: ConfigService) {
     this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
+    this.devRulesDirectory = this.configService.get<string>('DEV_RULES_DIRECTORY');
   }
 
   // Go through the rules directory and return a list of all JSON files
@@ -38,9 +40,9 @@ export class DocumentsService {
   }
 
   // Get the content of a specific JSON file
-  async getFileContent(ruleFileName: string): Promise<Buffer> {
+  async getFileContent(ruleFileName: string, isDev: boolean = false): Promise<Buffer> {
     try {
-      return await readFileSafely(this.rulesDirectory, ruleFileName);
+      return await readFileSafely(isDev ? this.devRulesDirectory : this.rulesDirectory, ruleFileName);
     } catch (error) {
       if (error instanceof FileNotFoundError) {
         throw new HttpException('File not found', HttpStatus.NOT_FOUND);

--- a/src/api/documents/documents.service.ts
+++ b/src/api/documents/documents.service.ts
@@ -6,17 +6,16 @@ import { readFileSafely, FileNotFoundError } from '../../utils/readFile';
 
 @Injectable()
 export class DocumentsService {
-  rulesDirectory: string;
-  devRulesDirectory: string;
+  baseRulesDirectory: string;
 
   constructor(private configService: ConfigService) {
-    this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
-    this.devRulesDirectory = this.configService.get<string>('DEV_RULES_DIRECTORY');
+    this.baseRulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
   }
 
   // Go through the rules directory and return a list of all JSON files
-  async getAllJSONFiles(directory: string = this.rulesDirectory): Promise<string[]> {
+  async getAllJSONFiles(ruleDir: string = ''): Promise<string[]> {
     const jsonFiles: string[] = [];
+    const directory = path.join(this.baseRulesDirectory, ruleDir);
 
     async function readDirectory(dir: string, baseDir: string) {
       const files = await fsPromises.readdir(dir, { withFileTypes: true });
@@ -40,9 +39,9 @@ export class DocumentsService {
   }
 
   // Get the content of a specific JSON file
-  async getFileContent(ruleFileName: string, isDev: boolean = false): Promise<Buffer> {
+  async getFileContent(ruleFileName: string): Promise<Buffer> {
     try {
-      return await readFileSafely(isDev ? this.devRulesDirectory : this.rulesDirectory, ruleFileName);
+      return await readFileSafely(this.baseRulesDirectory, ruleFileName);
     } catch (error) {
       if (error instanceof FileNotFoundError) {
         throw new HttpException('File not found', HttpStatus.NOT_FOUND);

--- a/src/api/klamm/klamm.service.ts
+++ b/src/api/klamm/klamm.service.ts
@@ -174,7 +174,8 @@ export class KlammService {
 
   async _getInputOutputFieldsData(rule: RuleData): Promise<{ inputs: KlammField[]; outputs: KlammField[] }> {
     try {
-      const { inputs, resultOutputs } = await this.ruleMappingService.inputOutputSchemaFile(rule.filepath);
+      const ruleDir = 'prod'; // Currently sycning with prod rules
+      const { inputs, resultOutputs } = await this.ruleMappingService.inputOutputSchemaFile(rule.filepath, ruleDir);
       const inputIds = inputs.map(({ id }) => Number(id));
       const outputIds = resultOutputs.map(({ id }) => Number(id));
       const klammFields: KlammField[] = await this._getAllKlammFields();

--- a/src/api/ruleData/ruleData.controller.spec.ts
+++ b/src/api/ruleData/ruleData.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { RuleDataController } from './ruleData.controller';
 import { RuleDataService } from './ruleData.service';
 import { RuleData } from './ruleData.schema';
-import { mockRuleData, mockServiceProviders } from './ruleData.service.spec';
+import { mockRuleData, mockRuleDataServiceProviders } from './ruleData.service.spec';
 
 describe('RuleDataController', () => {
   let controller: RuleDataController;
@@ -11,7 +11,7 @@ describe('RuleDataController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RuleDataController],
-      providers: mockServiceProviders,
+      providers: mockRuleDataServiceProviders,
     }).compile();
 
     controller = module.get<RuleDataController>(RuleDataController);

--- a/src/api/ruleData/ruleData.controller.ts
+++ b/src/api/ruleData/ruleData.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Post, Body, Put, Delete, HttpException, HttpStatus, Query } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiParam, ApiBody, ApiQuery } from '@nestjs/swagger';
 import { RuleDataService } from './ruleData.service';
 import { RuleData } from './ruleData.schema';
 import { RuleDraft } from './ruleDraft.schema';
@@ -30,8 +30,50 @@ export class RuleDataController {
     }
   }
 
+  @Get('/draft/filepath')
+  @ApiOperation({ summary: 'Get a rule draft from a given rule filepath' })
+  @ApiQuery({
+    name: 'filepath',
+    description: 'The filepath of the rule',
+    example: ruleExample.filepath,
+    required: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule draft retrieved successfully',
+    example: '676362648cb89c8b157adb5a',
+  })
+  async getRuleDraftByFilepath(@Query('filepath') filepath: string): Promise<RuleDraft> {
+    try {
+      return await this.ruleDataService.getRuleDataWithDraftByFilepath(filepath);
+    } catch (error) {
+      throw new HttpException('Error getting draft data', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('/filepath')
+  @ApiOperation({ summary: 'Get rule data by filepath' })
+  @ApiQuery({
+    name: 'filepath',
+    description: 'The filepath of the rule',
+    example: ruleExample.filepath,
+    required: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Rule data retrieved successfully',
+    type: RuleData,
+  })
+  async getRuleDataByFilepath(@Query('filepath') filepath: string): Promise<RuleData> {
+    try {
+      return await this.ruleDataService.getRuleDataByFilepath(filepath);
+    } catch (error) {
+      throw new HttpException('Error getting rule data by filepath', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
   @Get('/draft/:ruleId')
-  @ApiOperation({ summary: 'Get a rule draft ID from a given rule ID' })
+  @ApiOperation({ summary: 'Get a rule draft from a given rule ID' })
   @ApiParam({ name: 'ruleId', description: 'The ID of the rule', example: ruleExample._id })
   @ApiResponse({
     status: 200,

--- a/src/api/ruleData/ruleData.service.spec.ts
+++ b/src/api/ruleData/ruleData.service.spec.ts
@@ -30,7 +30,7 @@ class MockRuleDataModel {
   static exec = jest.fn().mockResolvedValue([mockRuleData]);
 }
 
-export const mockServiceProviders = [
+export const mockRuleDataServiceProviders = [
   RuleDataService,
   {
     provide: getModelToken(RuleDraft.name),
@@ -55,7 +55,7 @@ describe('RuleDataService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: mockServiceProviders,
+      providers: mockRuleDataServiceProviders,
     }).compile();
 
     service = module.get<RuleDataService>(RuleDataService);

--- a/src/api/ruleData/ruleVersion.ts
+++ b/src/api/ruleData/ruleVersion.ts
@@ -1,0 +1,7 @@
+export enum RULE_VERSION {
+  draft = 'draft',
+  inReview = 'inReview',
+  inDev = 'inDev',
+  inProduction = 'inProduction',
+  embedded = 'embedded',
+}

--- a/src/api/ruleMapping/ruleMapping.controller.ts
+++ b/src/api/ruleMapping/ruleMapping.controller.ts
@@ -16,6 +16,7 @@ export class RuleMappingController {
   @ApiBody({
     schema: {
       example: {
+        ruleDir: 'prod',
         filepath: ruleExample.filepath,
         ruleContent: ruleContentExample,
       },
@@ -32,45 +33,17 @@ export class RuleMappingController {
     },
   })
   async getRuleSchema(
+    @Body('ruleDir') ruleDir: string,
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: EvaluateRuleMappingDto,
     @Res() res: Response,
   ) {
-    const rulemap = await this.ruleMappingService.inputOutputSchema(ruleContent);
+    const rulemap = await this.ruleMappingService.inputOutputSchema(ruleDir, ruleContent);
 
     try {
       res.setHeader('Content-Type', 'application/json');
       res.setHeader('Content-Disposition', `attachment; filename=${filepath}`);
       res.send(rulemap);
-    } catch (error) {
-      if (error instanceof InvalidRuleContent) {
-        throw new HttpException('Invalid rule content', HttpStatus.BAD_REQUEST);
-      } else {
-        throw new HttpException('Internal server error', HttpStatus.INTERNAL_SERVER_ERROR);
-      }
-    }
-  }
-
-  // Map a rule to its unique inputs, and all outputs
-  @Post('/evaluate')
-  @ApiOperation({ summary: 'Evaluate rule mapping' })
-  @ApiBody({ type: EvaluateRuleMappingDto })
-  @ApiResponse({
-    status: 201,
-    description: 'Rule mapping evaluated successfully',
-    schema: {
-      example: {
-        result: {
-          inputs: ruleInputMetadata,
-          resultOutputs: ruleOutputMetadata,
-        },
-      },
-    },
-  })
-  async evaluateRuleMap(@Body() ruleContent: EvaluateRuleMappingDto) {
-    try {
-      const result = await this.ruleMappingService.inputOutputSchema(ruleContent);
-      return { result };
     } catch (error) {
       if (error instanceof InvalidRuleContent) {
         throw new HttpException('Invalid rule content', HttpStatus.BAD_REQUEST);
@@ -115,6 +88,7 @@ export class RuleMappingController {
   @ApiBody({
     schema: {
       example: {
+        ruleDir: 'dev',
         ruleContent: ruleContentExample,
       },
     },
@@ -130,10 +104,11 @@ export class RuleMappingController {
     },
   })
   async generateWithoutInputOutputNodes(
+    @Body('ruleDir') ruleDir: string,
     @Body('ruleContent') ruleContent: EvaluateRuleMappingDto,
     @Res() res: Response,
   ) {
-    const rulemap = await this.ruleMappingService.ruleSchema(ruleContent);
+    const rulemap = await this.ruleMappingService.ruleSchema(ruleDir, ruleContent);
 
     try {
       res.setHeader('Content-Type', 'application/json');

--- a/src/api/ruleMapping/ruleMapping.module.ts
+++ b/src/api/ruleMapping/ruleMapping.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { RuleMappingController } from './ruleMapping.controller';
 import { RuleMappingService } from './ruleMapping.service';
-import { DocumentsService } from '../documents/documents.service';
+import { RuleDataModule } from '../ruleData/ruleData.module';
 
 @Module({
+  imports: [RuleDataModule],
   controllers: [RuleMappingController],
-  providers: [RuleMappingService, DocumentsService],
+  providers: [RuleMappingService, RuleDataModule],
   exports: [RuleMappingService],
 })
 export class RuleMappingModule {}

--- a/src/api/ruleMapping/ruleMapping.service.spec.ts
+++ b/src/api/ruleMapping/ruleMapping.service.spec.ts
@@ -1,20 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RuleMappingService, InvalidRuleContent } from './ruleMapping.service';
 import { Node, TraceObject, Edge, RuleContent } from './ruleMapping.interface';
-import { DocumentsService } from '../documents/documents.service';
 import { ConfigService } from '@nestjs/config';
+import { RuleDataService } from '../ruleData/ruleData.service';
 
 describe('RuleMappingService', () => {
   let service: RuleMappingService;
-  let documentsService: DocumentsService;
+  let ruleDataService: RuleDataService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RuleMappingService,
-        DocumentsService,
+        RuleDataService,
         {
-          provide: DocumentsService,
+          provide: RuleDataService,
           useValue: {
             getFileContent: jest.fn(),
           },
@@ -29,7 +29,7 @@ describe('RuleMappingService', () => {
     }).compile();
 
     service = module.get<RuleMappingService>(RuleMappingService);
-    documentsService = module.get<DocumentsService>(DocumentsService);
+    ruleDataService = module.get<RuleDataService>(RuleDataService);
   });
 
   it('should be defined', () => {
@@ -943,7 +943,7 @@ describe('RuleMappingService', () => {
       });
 
       const mockGetFileContent = jest.fn().mockResolvedValue(Buffer.from(mockFileContent));
-      documentsService.getFileContent = mockGetFileContent;
+      ruleDataService.getContentForRuleFromFilepath = mockGetFileContent;
 
       const filePath = 'path/to/mock/file.json';
       const result = await service.ruleSchemaFile(filePath);
@@ -1306,7 +1306,7 @@ describe('RuleMappingService', () => {
       });
 
       const mockGetFileContent = jest.fn().mockResolvedValue(Buffer.from(mockFileContent));
-      documentsService.getFileContent = mockGetFileContent;
+      ruleDataService.getContentForRuleFromFilepath = mockGetFileContent;
 
       const filePath = 'path/to/mock/file.json';
       const result = await service.inputOutputSchemaFile(filePath);

--- a/src/api/ruleMapping/ruleMapping.service.ts
+++ b/src/api/ruleMapping/ruleMapping.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { Node, Edge, TraceObject, Field, RuleContent } from './ruleMapping.interface';
-import { DocumentsService } from '../documents/documents.service';
+import { RuleDataService } from '../ruleData/ruleData.service';
 import { ConfigService } from '@nestjs/config';
 import { RuleSchema, RuleField } from '../scenarioData/scenarioData.interface';
-
 export class InvalidRuleContent extends Error {
   constructor(message: string) {
     super(message);
@@ -15,7 +14,7 @@ export class InvalidRuleContent extends Error {
 export class RuleMappingService {
   rulesDirectory: string;
   constructor(
-    private documentsService: DocumentsService,
+    private ruleDataService: RuleDataService,
     private configService: ConfigService,
   ) {
     this.rulesDirectory = this.configService.get<string>('RULES_DIRECTORY');
@@ -177,9 +176,9 @@ export class RuleMappingService {
     return { inputs, outputs, resultOutputs };
   }
 
-  // generate a rule schema from a given local file
-  async ruleSchemaFile(ruleFileName: string): Promise<any> {
-    const fileContent = await this.documentsService.getFileContent(ruleFileName);
+  // generate a rule schema from a given rule filepath
+  async ruleSchemaFile(ruleFilepath: string): Promise<any> {
+    const fileContent = await this.ruleDataService.getContentForRuleFromFilepath(ruleFilepath);
     const ruleContent = await JSON.parse(fileContent.toString());
     return this.ruleSchema(ruleContent);
   }
@@ -262,8 +261,8 @@ export class RuleMappingService {
     return { inputs, resultOutputs };
   }
 
-  async inputOutputSchemaFile(ruleFileName: string): Promise<RuleSchema> {
-    const fileContent = await this.documentsService.getFileContent(ruleFileName);
+  async inputOutputSchemaFile(ruleFilepath: string): Promise<RuleSchema> {
+    const fileContent = await this.ruleDataService.getContentForRuleFromFilepath(ruleFilepath);
     const ruleContent = JSON.parse(fileContent.toString());
     return this.inputOutputSchema(ruleContent);
   }

--- a/src/api/scenarioData/scenarioData.controller.ts
+++ b/src/api/scenarioData/scenarioData.controller.ts
@@ -185,6 +185,7 @@ export class ScenarioDataController {
   @ApiBody({
     schema: {
       properties: {
+        ruleDir: { type: 'string', example: 'prod' },
         filepath: { type: 'string', description: 'Path to the rule file', example: ruleExample.filepath },
         ruleContent: { type: 'object', description: 'Rule file body', example: ruleContentExample },
       },
@@ -195,12 +196,17 @@ export class ScenarioDataController {
     description: 'CSV file generated successfully',
   })
   async getCSVForRuleRun(
+    @Body('ruleDir') ruleDir: string,
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: RuleContent,
     @Res() res: Response,
   ) {
     try {
-      const { allTestsPassed, csvContent } = await this.scenarioDataService.getCSVForRuleRun(filepath, ruleContent);
+      const { allTestsPassed, csvContent } = await this.scenarioDataService.getCSVForRuleRun(
+        ruleDir,
+        filepath,
+        ruleContent,
+      );
       // Add header that notes if all tests passed or not
       res.setHeader('X-All-Tests-Passed', allTestsPassed.toString());
       this.sendCSV(res, csvContent, filepath);
@@ -214,6 +220,7 @@ export class ScenarioDataController {
   @ApiBody({
     schema: {
       properties: {
+        ruleDir: { type: 'string', example: 'prod' },
         filepath: { type: 'string', example: ruleExample.filepath },
         ruleContent: { type: 'object', example: ruleContentExample },
       },
@@ -229,11 +236,12 @@ export class ScenarioDataController {
     },
   })
   async runDecisionsForScenarios(
+    @Body('ruleDir') ruleDir: string,
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: RuleContent,
   ): Promise<{ [scenarioId: string]: any }> {
     try {
-      return await this.scenarioDataService.runDecisionsForScenarios(filepath, ruleContent);
+      return await this.scenarioDataService.runDecisionsForScenarios(ruleDir, filepath, ruleContent);
     } catch (error) {
       throw new HttpException('Error running scenario decisions', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -246,6 +254,7 @@ export class ScenarioDataController {
     schema: {
       type: 'object',
       properties: {
+        ruleDir: { type: 'string', example: 'prod' },
         file: {
           type: 'string',
           format: 'binary',
@@ -278,6 +287,7 @@ export class ScenarioDataController {
   async uploadCSVAndProcess(
     @UploadedFile() file: Express.Multer.File | undefined,
     @Res() res: Response,
+    @Body('ruleDir') ruleDir: string,
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: RuleContent,
   ) {
@@ -288,6 +298,7 @@ export class ScenarioDataController {
     try {
       const scenarios = await this.scenarioDataService.processProvidedScenarios(filepath, file);
       const { allTestsPassed, csvContent } = await this.scenarioDataService.getCSVForRuleRun(
+        ruleDir,
         filepath,
         typeof ruleContent === 'string' ? JSON.parse(ruleContent) : ruleContent,
         scenarios,
@@ -305,6 +316,7 @@ export class ScenarioDataController {
   @ApiBody({
     schema: {
       properties: {
+        ruleDir: { type: 'string', example: 'prod' },
         filepath: { type: 'string', example: ruleExample.filepath },
         ruleContent: { type: 'object', example: ruleContentExample },
         simulationContext: { type: 'object', example: ruleInputs },
@@ -325,6 +337,7 @@ export class ScenarioDataController {
     },
   })
   async getCSVTests(
+    @Body('ruleDir') ruleDir: string,
     @Body('filepath') filepath: string,
     @Body('ruleContent') ruleContent: RuleContent,
     @Body('simulationContext') simulationContext: RuleRunResults,
@@ -333,6 +346,7 @@ export class ScenarioDataController {
   ) {
     try {
       const fileContent = await this.scenarioDataService.generateTestCSVScenarios(
+        ruleDir,
         filepath,
         ruleContent,
         simulationContext,

--- a/src/api/scenarioData/scenarioData.service.spec.ts
+++ b/src/api/scenarioData/scenarioData.service.spec.ts
@@ -4,11 +4,11 @@ import { ScenarioDataService } from './scenarioData.service';
 import { getModelToken } from '@nestjs/mongoose';
 import { Types, Model } from 'mongoose';
 import { ConfigService } from '@nestjs/config';
+import { mockRuleDataServiceProviders } from '../ruleData/ruleData.service.spec';
 import { ScenarioData, ScenarioDataDocument } from './scenarioData.schema';
 import { RuleSchema } from './scenarioData.interface';
 import { DecisionsService } from '../decisions/decisions.service';
 import { RuleMappingService } from '../ruleMapping/ruleMapping.service';
-import { DocumentsService } from '../documents/documents.service';
 import { parseCSV, getScenariosFromParsedCSV, complexCartesianProduct } from '../../utils/csv';
 
 jest.mock('../../utils/csv');
@@ -56,6 +56,7 @@ describe('ScenarioDataService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        ...mockRuleDataServiceProviders,
         DecisionsService,
         RuleMappingService,
         ScenarioDataService,
@@ -63,7 +64,6 @@ describe('ScenarioDataService', () => {
           provide: getModelToken(ScenarioData.name),
           useValue: MockScenarioDataModel,
         },
-        DocumentsService,
         {
           provide: ConfigService,
           useValue: {

--- a/src/api/scenarioData/scenarioData.service.ts
+++ b/src/api/scenarioData/scenarioData.service.ts
@@ -111,6 +111,7 @@ export class ScenarioDataService {
    * Maps inputs and outputs from decision traces to structured results.
    */
   async runDecisionsForScenarios(
+    ruleDir: string,
     filepath: string,
     ruleContent?: RuleContent,
     newScenarios?: ScenarioData[],
@@ -120,7 +121,7 @@ export class ScenarioDataService {
       const fileContent = await this.documentsService.getFileContent(filepath);
       ruleContent = await JSON.parse(fileContent.toString());
     }
-    const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleContent);
+    const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleDir, ruleContent);
     const results: { [scenarioId: string]: any } = {};
     for (const scenario of scenarios as ScenarioDataDocument[]) {
       const formattedVariablesObject = reduceToCleanObj(scenario?.variables, 'name', 'value');
@@ -171,11 +172,17 @@ export class ScenarioDataService {
    * Constructs CSV headers and rows based on input and output keys.
    */
   async getCSVForRuleRun(
+    ruleDir: string,
     filepath: string,
     ruleContent: RuleContent,
     newScenarios?: ScenarioData[],
   ): Promise<{ allTestsPassed: boolean; csvContent: string }> {
-    const ruleRunResults: RuleRunResults = await this.runDecisionsForScenarios(filepath, ruleContent, newScenarios);
+    const ruleRunResults: RuleRunResults = await this.runDecisionsForScenarios(
+      ruleDir,
+      filepath,
+      ruleContent,
+      newScenarios,
+    );
 
     const keys = {
       inputs: extractUniqueKeys(ruleRunResults, 'inputs'),
@@ -586,6 +593,7 @@ export class ScenarioDataService {
   }
 
   async generateTestScenarios(
+    ruleDir: string,
     filepath: string,
     ruleContent?: RuleContent,
     simulationContext?: RuleRunResults,
@@ -596,7 +604,7 @@ export class ScenarioDataService {
       const fileContent = await this.documentsService.getFileContent(filepath);
       ruleContent = await JSON.parse(fileContent.toString());
     }
-    const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleContent);
+    const ruleSchema: RuleSchema = await this.ruleMappingService.inputOutputSchema(ruleDir, ruleContent);
     const combinations = this.generateCombinations(
       ruleSchema,
       simulationContext,
@@ -658,6 +666,7 @@ export class ScenarioDataService {
   }
 
   async generateTestCSVScenarios(
+    ruleDir: string,
     filepath: string,
     ruleContent: RuleContent,
     simulationContext: RuleRunResults,
@@ -665,6 +674,7 @@ export class ScenarioDataService {
   ) {
     try {
       const ruleRunResults: RuleRunResults = await this.generateTestScenarios(
+        ruleDir,
         filepath,
         ruleContent,
         simulationContext,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { ScenarioDataService } from './api/scenarioData/scenarioData.service';
       load: [
         () => ({
           RULES_DIRECTORY: process.env.RULES_DIRECTORY || 'brms-rules/rules',
+          DEV_RULES_DIRECTORY: process.env.DEV_RULES_DIRECTORY || 'dev/brms-rules/rules',
         }),
       ],
     }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,8 +19,7 @@ import { ScenarioDataService } from './api/scenarioData/scenarioData.service';
       isGlobal: true, // Make the ConfigModule globally available
       load: [
         () => ({
-          RULES_DIRECTORY: process.env.RULES_DIRECTORY || 'brms-rules/rules',
-          DEV_RULES_DIRECTORY: process.env.DEV_RULES_DIRECTORY || 'dev/brms-rules/rules',
+          RULES_DIRECTORY: process.env.RULES_DIRECTORY || 'rules',
         }),
       ],
     }),

--- a/src/run-csv-tests.ts
+++ b/src/run-csv-tests.ts
@@ -27,6 +27,7 @@ import { getScenariosFromParsedCSV } from './utils/csv';
 import { RuleMappingService } from './api/ruleMapping/ruleMapping.service';
 import { DocumentsService } from './api/documents/documents.service';
 import { ScenarioDataService } from './api/scenarioData/scenarioData.service';
+import { RuleDataService } from './api/ruleData/ruleData.service';
 
 interface CSVFilesForRule {
   testFilePath: string;
@@ -42,9 +43,10 @@ class CsvTestRunner {
 
   private configService = new ConfigService({ RULES_DIRECTORY });
   private logger = new Logger();
-  private decisionService = new DecisionsService(this.configService, this.logger);
   private documentsService = new DocumentsService(this.configService);
-  private ruleMappingService = new RuleMappingService(this.documentsService, this.configService);
+  private ruleDataService = new RuleDataService(null, null, this.documentsService, this.logger);
+  private decisionService = new DecisionsService(this.ruleDataService, this.logger);
+  private ruleMappingService = new RuleMappingService(this.ruleDataService, this.configService);
   public scenarioDataService = new ScenarioDataService(
     this.decisionService,
     this.ruleMappingService,


### PR DESCRIPTION
- [x] Updates how rules for main and dev are stored - accessible by file regardless of location
- [x] Updated to support running a separate dev set of rules - can request either the production or dev version of a rule from the server
- [x] Added ability to get rule content for each version type including draft and inReview
- [x] Added endpoint for getting draft version of a rule just by filepath
- [x] Added endpoint to get ruleData just from filepath
- [x] Removed ununsed function