### PR TITLE
Multitenant backend updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build Image
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch: # Allows us to trigger this workflow from elsewhere (like the rules repo)
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Extract current branch name
+        id: extract_branch
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/csv-rule-tests.yml
+++ b/.github/workflows/csv-rule-tests.yml
@@ -24,10 +24,8 @@ jobs:
       # Checks for names of rule repositories in RULES_REPOSITORIES environment variable
       # Clones the repositories into their own folders and runs the tests for them
       - name: Clone additional repositories and run tests
-        env:
-          RULES_REPOSITORIES: bcgov/brms-rules
         run: |
-          IFS=',' read -r -a repos <<< "$RULES_REPOSITORIES"
+          IFS=',' read -r -a repos <<< "${{ vars.RULES_REPOSITORIES }}"
           for repo in "${repos[@]}"; do
             git clone -b dev "https://github.com/$repo.git" "$repo"
             npm run test:rules $repo

--- a/.github/workflows/csv-rule-tests.yml
+++ b/.github/workflows/csv-rule-tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - dev
-      - feature/pipeline-rule-tests
+      - feature/multitenant-improvements #TODO: Remove before merge
   pull_request:
     branches:
       - main
@@ -21,8 +21,14 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Clone additional repository
-        run: git clone -b dev https://github.com/bcgov/brms-rules.git brms-rules
-
-      - name: Run CSV tests
-        run: npm run test:rules
+      # Checks for names of rule repositories in RULES_REPOSITORIES environment variable
+      # Clones the repositories into their own folders and runs the tests for them
+      - name: Clone additional repositories and run tests
+        env:
+          RULES_REPOSITORIES: bcgov/brms-rules
+        run: |
+          IFS=',' read -r -a repos <<< "$RULES_REPOSITORIES"
+          for repo in "${repos[@]}"; do
+            git clone -b dev "https://github.com/$repo.git" "$repo"
+            npm run test:rules $repo
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,52 +1,13 @@
-name: Build and Deploy
+name: Deploy to OpenShift
 
 on:
   push:
     branches:
       - main
       - dev
-      - pipeline
   workflow_dispatch: # Allows us to trigger this workflow from elsewhere (like the rules repo)
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build_image:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Login to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Extract current branch name
-        id: extract_branch
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-    outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
-
   deploy:
     needs: build_image
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,22 @@ jobs:
           openshift_token: ${{ github.ref == 'refs/heads/main' && secrets.OPENSHIFT_PROD_TOKEN  || secrets.OPENSHIFT_DEV_TOKEN  }}
           insecure_skip_tls_verify: true
 
+      - name: Clone production rules repository
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p rules/prod
+          git clone -b main https://github.com/bcgov/brms-rules.git ./tmp-brm-rules
+          mv ./tmp-brm-rules/rules/* rules/prod
+          rm -rf ./tmp-brm-rules
+
+      - name: Clone dev rules repository
+        if: github.ref == 'refs/heads/dev'
+        run: |
+          mkdir -p rules/dev
+          git clone -b dev https://github.com/bcgov/brms-rules.git ./tmp-brm-rules
+          mv ./tmp-brm-rules/rules/* rules/dev
+          rm -rf ./tmp-brm-rules
+
       - name: Run Helm
         run: |
           helm upgrade --install brm-backend ./helm --set image.tag=${{ needs.build_image.outputs.image_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,5 @@ RUN npm ci
 # Copy the application code
 COPY . ./
 
-# Clone the production rules repository into rules/prod
-RUN mkdir -p rules/prod && \
-    git clone -b main https://github.com/bcgov/brms-rules.git ./tmp-brm-rules && \
-    mv ./tmp-brm-rules/rules/* rules/prod && \
-    rm -rf ./tmp-brm-rules
-
-# Clone the dev rules repository into rules/dev
-RUN mkdir -p rules/dev && \
-    git clone -b dev https://github.com/bcgov/brms-rules.git ./tmp-brm-rules && \
-    mv ./tmp-brm-rules/rules/* rules/dev && \
-    rm -rf ./tmp-brm-rules
-
 # Start the application
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ The API will now be available at [http://localhost:3000](http://localhost:3000).
 
 ## Running the CSV Tests
 
+TODO: Add information here
+
 ## The Deployment Pipeline
+
+TODO: Add information here
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BRM (Business Rules Management) Backend
 
-This project is the Backend for the SDPR Business Rules Engine (BRE) and [BRM App](https://github.com/bcgov/brm-app).
+This project is the Backend for the [BRM App](https://github.com/bcgov/brm-app), supporting business rule authoring and execution. It was made for SDPR's Business Rules Engine (BRE).
 
 ## Local Development Setup
 
@@ -21,7 +21,9 @@ To set up MongoDB and populate it with initial data, follow these steps:
 
 ### Including Rules from the Rules Repository
 
-To get access to rules locally on your machine simply clone the repo at https://github.com/bcgov/brms-rules and ensure the rules are placed at the brm-backend/rules/prod location (for main branch/production rules) or brm-backend/rules/dev location (for dev branch/dev rules).
+To get access to rules locally on your machine simply clone your repo into the project and ensure the rules are placed at the brm-backend/rules/prod location (for main branch/production rules) or brm-backend/rules/dev location (for dev branch/dev rules).
+
+For example:
 
 ```bash
 git clone https://github.com/bcgov/brms-rules.git
@@ -37,7 +39,7 @@ Before running your application locally, you'll need some environment variables.
 
 - MONGODB_URL: The URL for connecting to the MongoDB instance you created in the previous step. Should be mongodb://localhost:27017/brms-db.
 - FRONTEND_URI: The URI for the frontend application. Set it to http://localhost:8080.
-- GITHUB_RULES_BRANCH: Specifies which branch Klamm is syncing with
+- GITHUB_RULES_REPO: Set to whatever the api address of your GitHub rules repo is, like https://api.github.com/repos/bcgov/brms-rules
 - GITHUB_TOKEN: Optional github token to mitigate issues with rate limiting
 - GITHUB_APP_CLIENT_ID
 - GITHUB_APP_CLIENT_SECRET
@@ -59,6 +61,10 @@ npm run dev
 ```
 
 The API will now be available at [http://localhost:3000](http://localhost:3000).
+
+## Running the CSV Tests
+
+## The Deployment Pipeline
 
 ## How to Contribute
 

--- a/src/api/documents/documents.service.spec.ts
+++ b/src/api/documents/documents.service.spec.ts
@@ -13,7 +13,6 @@ jest.mock('../../utils/readFile', () => ({
 }));
 
 jest.mock('fs/promises');
-const RULES_DIRECTORY = '../../../rules-repo/rules';
 
 describe('DocumentsService', () => {
   let service: DocumentsService;
@@ -24,7 +23,7 @@ describe('DocumentsService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue(RULES_DIRECTORY),
+            get: jest.fn().mockReturnValue('rules'),
           },
         },
         DocumentsService,
@@ -99,8 +98,8 @@ describe('DocumentsService', () => {
       expect(result).toEqual(['file1.json', 'subdir/file4.json', 'file3.JSON']);
 
       expect(fsPromises.readdir).toHaveBeenCalledTimes(2);
-      expect(fsPromises.readdir).toHaveBeenCalledWith(RULES_DIRECTORY, { withFileTypes: true });
-      expect(fsPromises.readdir).toHaveBeenCalledWith(path.join(RULES_DIRECTORY, 'subdir'), { withFileTypes: true });
+      expect(fsPromises.readdir).toHaveBeenCalledWith('rules', { withFileTypes: true });
+      expect(fsPromises.readdir).toHaveBeenCalledWith(path.join('rules', 'subdir'), { withFileTypes: true });
     });
 
     it('should throw HttpException when directory reading fails', async () => {
@@ -118,7 +117,7 @@ describe('DocumentsService', () => {
 
       expect(result).toEqual([]);
       expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
-      expect(fsPromises.readdir).toHaveBeenCalledWith(RULES_DIRECTORY, { withFileTypes: true });
+      expect(fsPromises.readdir).toHaveBeenCalledWith('rules', { withFileTypes: true });
     });
 
     it('should ignore non-JSON files', async () => {
@@ -146,7 +145,7 @@ describe('DocumentsService', () => {
 
       expect(result).toEqual([]);
       expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
-      expect(fsPromises.readdir).toHaveBeenCalledWith(RULES_DIRECTORY, { withFileTypes: true });
+      expect(fsPromises.readdir).toHaveBeenCalledWith('rules', { withFileTypes: true });
     });
   });
 
@@ -166,7 +165,7 @@ describe('DocumentsService', () => {
       const result = await service.getFileContent('path/to/existing/file');
 
       expect(result).toBe(mockContent);
-      expect(readFileSafely).toHaveBeenCalledWith(RULES_DIRECTORY, 'path/to/existing/file');
+      expect(readFileSafely).toHaveBeenCalledWith('rules', 'path/to/existing/file');
     });
 
     it('should throw a 500 error if reading the file fails', async () => {

--- a/src/api/documents/documents.service.spec.ts
+++ b/src/api/documents/documents.service.spec.ts
@@ -13,7 +13,7 @@ jest.mock('../../utils/readFile', () => ({
 }));
 
 jest.mock('fs/promises');
-const RULES_DIRECTORY = '../../../brms-rules/rules';
+const RULES_DIRECTORY = '../../../rules-repo/rules';
 
 describe('DocumentsService', () => {
   let service: DocumentsService;

--- a/src/api/klamm/klamm.service.spec.ts
+++ b/src/api/klamm/klamm.service.spec.ts
@@ -105,7 +105,7 @@ describe('KlammService', () => {
 
     expect(service['_getLastSyncTimestamp']).toHaveBeenCalled();
     expect(service.axiosGithubInstance.get).toHaveBeenCalledWith(
-      `${GITHUB_RULES_REPO}/commits?since=${new Date(1234567890).toISOString().split('.')[0]}Z&sha=${process.env.GITHUB_RULES_BRANCH}`,
+      `${GITHUB_RULES_REPO}/commits?since=${new Date(1234567890).toISOString().split('.')[0]}Z&sha=dev`,
     );
     expect(result.updatedFilesSinceLastDeploy).toEqual(mockFiles);
   });

--- a/src/api/klamm/klamm.service.ts
+++ b/src/api/klamm/klamm.service.ts
@@ -10,7 +10,7 @@ import { RuleData } from '../ruleData/ruleData.schema';
 import { DocumentsService } from '../documents/documents.service';
 import { KlammSyncMetadata, KlammSyncMetadataDocument } from './klammSyncMetadata.schema';
 
-export const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO || 'https://api.github.com/repos/bcgov/brms-rules';
+export const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO;
 
 export class InvalidFieldRequest extends Error {
   constructor(message: string) {
@@ -124,8 +124,10 @@ export class KlammService {
       const formattedDate = date.toISOString().split('.')[0] + 'Z'; // Format required for github api
       this.logger.log(`Getting files from Github from ${formattedDate} onwards...`);
       // Fetch commits since the specified timestamp
+      // The dev branch is used because the rules should always be updated on the dev branch before production
+      // so this is an appropriate reference to sync from
       const commitsResponse = await this.axiosGithubInstance.get(
-        `${GITHUB_RULES_REPO}/commits?since=${formattedDate}&sha=${process.env.GITHUB_RULES_BRANCH}`,
+        `${GITHUB_RULES_REPO}/commits?since=${formattedDate}&sha=dev`,
       );
       const commits = commitsResponse.data.reverse();
       let lastCommitAsyncTimestamp;

--- a/src/api/ruleData/ruleData.service.ts
+++ b/src/api/ruleData/ruleData.service.ts
@@ -10,7 +10,7 @@ import { deriveNameFromFilepath } from '../../utils/helpers';
 import { RULE_VERSION } from './ruleVersion';
 import { CategoryObject, PaginationDto } from './dto/pagination.dto';
 
-const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO || 'https://api.github.com/repos/bcgov/brms-rules';
+const GITHUB_RULES_REPO = process.env.GITHUB_RULES_REPO;
 
 @Injectable()
 export class RuleDataService {

--- a/src/run-csv-tests.ts
+++ b/src/run-csv-tests.ts
@@ -5,17 +5,14 @@
  * It is meant for running as part of the pipeline to ensure that the rules are working as expected.
  *
  * The script can be run in two modes:
- * 1. Run tests for all rules: If no specific rule path is provided as a command line argument,
+ * 1. Run tests for all rules in a repoo: If no specific rule path is provided as a command line argument,
  *    the script will find all CSV test files and run tests for all rules.
  * 2. Run tests for specified rules: If a comma-separated list of rule paths is provided as a
  *    command line argument, the script will run tests only for the specified rules.
  *
- * Environment Variables:
- * - RULES_DIRECTORY: The directory where the rules are stored (default: 'brms-rules/rules').
- * - CSV_TESTS_DIRECTORY: The directory where the CSV test files are stored (default: 'brms-rules/tests').
- *
  * Command Line Arguments:
- * - rulePathsToTest: A comma-separated list of rule paths to test. If not provided, all rules will be tested.
+ * - argv[1]: The path to the rules repository.
+ * - argv[2]: The rule path to test. If not provided, all rules in the repo will be tested.
  */
 import fs from 'fs';
 import path from 'path';
@@ -34,14 +31,11 @@ interface CSVFilesForRule {
   testFiles: string[];
 }
 
-const RULES_DIRECTORY = process.env.RULES_DIRECTORY || 'brms-rules/rules';
-const CSV_TESTS_DIRECTORY = process.env.CSV_TESTS_DIRECTORY || 'brms-rules/tests';
-
 class CsvTestRunner {
   private ruleStats = { ruleCount: 0, testCount: 0, failedCount: 0 };
   private failedTests: string[] = [];
 
-  private configService = new ConfigService({ RULES_DIRECTORY });
+  private configService = new ConfigService({ RULES_DIRECTORY: '.' });
   private logger = new Logger();
   private documentsService = new DocumentsService(this.configService);
   private ruleDataService = new RuleDataService(null, null, this.documentsService, this.logger);
@@ -83,18 +77,17 @@ class CsvTestRunner {
 
   /**
    * Retrieves the test files at a specified path.
-   * @param filePath - The path to search for test files.
+   * @param testFilePath - The path to search for test files.
    * @returns An object containing the relative path and an array of file names.
    */
-  getTestFilesAtRulePath(filePath: string): CSVFilesForRule {
-    const testFilePath = path.relative(CSV_TESTS_DIRECTORY, filePath);
+  getTestFilesAtRulePath(testFilePath: string): CSVFilesForRule {
     try {
-      const testFiles = fs.readdirSync(filePath)?.filter((subfile) => {
-        return fs.statSync(path.join(filePath, subfile)).isFile() && subfile.endsWith('.csv');
+      const testFiles = fs.readdirSync(testFilePath)?.filter((subfile) => {
+        return fs.statSync(path.join(testFilePath, subfile)).isFile() && subfile.endsWith('.csv');
       });
       return { testFilePath, testFiles };
     } catch (error) {
-      console.warn(filePath, error.message);
+      console.warn(testFilePath, error.message);
       return { testFilePath, testFiles: [] };
     }
   }
@@ -134,17 +127,18 @@ class CsvTestRunner {
    */
   public async runScenariosForCSVTestfile(ruleDir: string, testFilePath: string, testFile: string) {
     this.ruleStats.testCount++;
-    const fullTestFilePath = `${CSV_TESTS_DIRECTORY}/${testFilePath}/${testFile}`;
+    const relativeFilePath = path.relative(`${ruleDir}/tests`, testFilePath);
+    const fullTestFilePath = `${testFilePath}/${testFile}`;
     const testCSVFileContent = await fs.promises.readFile(fullTestFilePath, 'utf8');
     const testFileCSV: string[][] = this.convertCsvToArray(testCSVFileContent.trim());
-    const csvScenarios = getScenariosFromParsedCSV(testFileCSV, testFilePath);
-    const rulePath = `${testFilePath}.json`;
+    const csvScenarios = getScenariosFromParsedCSV(testFileCSV, relativeFilePath);
+    const rulePath = `${relativeFilePath}.json`;
     const hasNoExpectedResults = csvScenarios.some((scenario) => scenario.expectedResults.length === 0);
     if (hasNoExpectedResults) {
       console.warn(`\tMissing expected results for file ${testFile}`);
     }
     const { allTestsPassed, csvContent } = await this.scenarioDataService.getCSVForRuleRun(
-      rulePath,
+      `${ruleDir}/rules/${rulePath}`,
       null,
       ruleDir,
       csvScenarios,
@@ -194,9 +188,10 @@ class CsvTestRunner {
 
   /**
    * Test a rule at a specified path with the CSV test files there
+   * @param ruleRepoDir - The path to the rules repository
    * @param rulePathToTest - The path of the rule.
    */
-  async runTestsForSpecifiedRulePath(ruleDir, rulePathToTest?: string) {
+  async runTestsForSpecifiedRulePath(ruleRepoDir: string, rulePathToTest?: string) {
     if (rulePathToTest) {
       if (rulePathToTest.startsWith('rules/')) {
         rulePathToTest = rulePathToTest.slice(6);
@@ -205,20 +200,20 @@ class CsvTestRunner {
         rulePathToTest = rulePathToTest.slice(0, -5);
       }
     }
-    const { testFilePath, testFiles } = this.getTestFilesAtRulePath(`${CSV_TESTS_DIRECTORY}/${rulePathToTest}`);
+    const { testFilePath, testFiles } = this.getTestFilesAtRulePath(`${ruleRepoDir}/tests/${rulePathToTest}`);
     if (!testFiles || testFiles.length === 0) {
       return;
     }
-    await this.runTestsForRule(ruleDir, testFilePath, testFiles);
+    await this.runTestsForRule(ruleRepoDir, testFilePath, testFiles);
   }
 
   /**
    * Test rules at specified paths
    * @param rulePathToTests - comma separated list of rule paths to test.
    */
-  async runTestsForSpecifiedRulePaths(rulePathsToTest?: string) {
+  async runTestsForSpecifiedRulePaths(ruleRepoDir: string, rulePathsToTest?: string) {
     for (const rulePathToTest of rulePathsToTest.split(',')) {
-      await this.runTestsForSpecifiedRulePath(rulePathToTest);
+      await this.runTestsForSpecifiedRulePath(ruleRepoDir, rulePathToTest);
     }
     this.showFinalTestResults();
     process.exit(0);
@@ -227,12 +222,12 @@ class CsvTestRunner {
   /**
    * Runs all rules by getting all paths that have CSV test files and running tests for each rule.
    */
-  async runAllRules(ruleDir: string) {
+  async runAllRules(ruleRepoDir: string) {
     // Gets all paths that have CSV test files in them
-    const csvTestPaths = this.getTestPathsAndFiles(CSV_TESTS_DIRECTORY);
+    const csvTestPaths = this.getTestPathsAndFiles(`${ruleRepoDir}/tests`);
     // Run tests for each rule
     for (const { testFilePath, testFiles } of csvTestPaths) {
-      await this.runTestsForRule(ruleDir, testFilePath, testFiles);
+      await this.runTestsForRule(ruleRepoDir, testFilePath, testFiles);
     }
     this.showFinalTestResults();
     process.exit(0);
@@ -243,14 +238,21 @@ class CsvTestRunner {
    * @param argv - The command line arguments.
    */
   async main(argv: string[]) {
-    const rulePathsToTest = argv[2];
-
-    // Run tests for the specified rule path if it exists, otherwise run all rules
-    if (rulePathsToTest) {
-      await this.runTestsForSpecifiedRulePaths(rulePathsToTest);
-    } else {
-      await this.runAllRules('');
+    // Get the rules repository path and the rule paths to test from the command line arguments
+    const rulesRepoDirs = argv[2] || process.env.RULES_REPOSITORIES;
+    const rulePathsToTest = argv[3];
+    if (!rulesRepoDirs) {
+      throw new Error('Rules repository path is required');
     }
+    // For each rules repository path, run tests for the specified rule paths or all rules
+    rulesRepoDirs.split(',').forEach(async (ruleRepoDir) => {
+      // Run tests for the specified rule path if it exists, otherwise run all rules
+      if (rulePathsToTest) {
+        await this.runTestsForSpecifiedRulePaths(ruleRepoDir, rulePathsToTest);
+      } else {
+        await this.runAllRules(ruleRepoDir);
+      }
+    });
   }
 }
 

--- a/src/run-csv-tests.ts
+++ b/src/run-csv-tests.ts
@@ -5,7 +5,7 @@
  * It is meant for running as part of the pipeline to ensure that the rules are working as expected.
  *
  * The script can be run in two modes:
- * 1. Run tests for all rules in a repoo: If no specific rule path is provided as a command line argument,
+ * 1. Run tests for all rules in a repo: If no specific rule path is provided as a command line argument,
  *    the script will find all CSV test files and run tests for all rules.
  * 2. Run tests for specified rules: If a comma-separated list of rule paths is provided as a
  *    command line argument, the script will run tests only for the specified rules.

--- a/src/utils/readFile.spec.ts
+++ b/src/utils/readFile.spec.ts
@@ -4,8 +4,6 @@ import * as fs from 'fs';
 jest.mock('fs');
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
-const RULES_DIRECTORY = '../../../rules-repo/rules';
-
 describe('File Utility Functions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -15,7 +13,7 @@ describe('File Utility Functions', () => {
     it('should throw FileNotFoundError if path traversal detected', async () => {
       const mockInvalidFileName = '../traversal.txt';
 
-      await expect(readFileSafely(RULES_DIRECTORY, mockInvalidFileName)).rejects.toThrow(
+      await expect(readFileSafely('rules', mockInvalidFileName)).rejects.toThrow(
         new FileNotFoundError('Path traversal detected'),
       );
     });
@@ -23,7 +21,7 @@ describe('File Utility Functions', () => {
     it('should throw FileNotFoundError if file does not exist', async () => {
       mockedFs.existsSync.mockReturnValue(false);
 
-      await expect(readFileSafely(RULES_DIRECTORY, 'nonexistentFile.txt')).rejects.toThrow(
+      await expect(readFileSafely('rules', 'nonexistentFile.txt')).rejects.toThrow(
         new FileNotFoundError('File not found'),
       );
     });

--- a/src/utils/readFile.spec.ts
+++ b/src/utils/readFile.spec.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 jest.mock('fs');
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
-const RULES_DIRECTORY = '../../../brms-rules/rules';
+const RULES_DIRECTORY = '../../../rules-repo/rules';
 
 describe('File Utility Functions', () => {
   beforeEach(() => {


### PR DESCRIPTION
- [x] Removed GITHUB_RULES_BRANCH and logic around it
- [x] Break up build and deploy for more flexibility
- [x] Updated how CSV rule tests work and are run to allow multiple rules repositories
- [x] Updated to requiring a GITHUB_RULES_REPO env variable

https://knowledge.social.gov.bc.ca/successor/bre/deploying_your_own_business_rules_management_brm_app/start